### PR TITLE
feat: add cuisines resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@neondatabase/serverless": "^1.1.0",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.32",
+    "postgres": "^3.4.9",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,15 @@ importers:
 
   .:
     dependencies:
-      '@neondatabase/serverless':
-        specifier: ^1.1.0
-        version: 1.1.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.1.0)(postgres@3.4.9)
       hono:
         specifier: ^4.12.32
         version: 4.12.32
+      postgres:
+        specifier: ^3.4.9
+        version: 3.4.9
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2159,7 +2159,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@neondatabase/serverless@1.1.0': {}
+  '@neondatabase/serverless@1.1.0':
+    optional: true
 
   '@oxc-project/types@0.143.0': {}
 
@@ -2780,8 +2781,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgres@3.4.9:
-    optional: true
+  postgres@3.4.9: {}
 
   prelude-ls@1.2.1: {}
 

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,7 +1,7 @@
-import { neon } from '@neondatabase/serverless'
-import { drizzle } from 'drizzle-orm/neon-http'
+import postgres from 'postgres'
+import { drizzle } from 'drizzle-orm/postgres-js'
 
 export function createDb(connectionString: string) {
-  const sql = neon(connectionString)
-  return drizzle(sql)
+  const client = postgres(connectionString)
+  return drizzle(client)
 }

--- a/src/db/schema/cuisines.ts
+++ b/src/db/schema/cuisines.ts
@@ -1,0 +1,10 @@
+import { pgSchema, smallserial, varchar } from 'drizzle-orm/pg-core'
+
+const recipeservice = pgSchema('recipeservice')
+
+export const cuisines = recipeservice.table('cuisines', {
+  id: smallserial('cuisine_id').primaryKey(),
+  name: varchar('cuisine', { length: 100 }).notNull().unique(),
+})
+
+export type Cuisine = typeof cuisines.$inferSelect

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { authMiddleware } from './middleware/auth'
 import { errorHandler } from './middleware/errorHandler'
 import { rateLimiterMiddleware } from './middleware/rateLimiter'
+import { cuisineRouter } from './routes/cuisines'
 
 const app = new Hono<{ Bindings: CloudflareBindings }>()
 
@@ -12,7 +13,6 @@ app.get('/health', (c) => c.json({ status: 'ok' }))
 app.use('*', authMiddleware)
 app.use('*', rateLimiterMiddleware)
 
-// Future routes mount here:
-// app.route('/api/v1/recipes', recipesRouter)
+app.route('/cuisines', cuisineRouter)
 
 export default app

--- a/src/routes/cuisines.test.ts
+++ b/src/routes/cuisines.test.ts
@@ -1,0 +1,106 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authMiddleware } from '../middleware/auth'
+import * as cuisineService from '../services/cuisineService'
+import { cuisineRouter } from './cuisines'
+
+vi.mock('../db/client', () => ({ createDb: vi.fn(() => ({})) }))
+vi.mock('../services/cuisineService')
+
+type TestBindings = {
+  USER_API_KEY: string
+  ADMIN_API_KEY: string
+  DATABASE_URL: string
+}
+
+const USER_KEY = 'test-user-key'
+const ADMIN_KEY = 'test-admin-key'
+const TEST_ENV: TestBindings = {
+  USER_API_KEY: USER_KEY,
+  ADMIN_API_KEY: ADMIN_KEY,
+  DATABASE_URL: 'postgresql://test',
+}
+
+const SAMPLE_CUISINES = [
+  { id: 1, name: 'Italian' },
+  { id: 2, name: 'Mexican' },
+]
+
+function buildTestApp() {
+  const app = new Hono<{ Bindings: TestBindings }>()
+  app.use('*', authMiddleware)
+  app.route('/cuisines', cuisineRouter)
+  return app
+}
+
+const app = buildTestApp()
+
+function request(path: string, apiKey?: string) {
+  const headers: Record<string, string> = {}
+  if (apiKey !== undefined) headers['X-Api-Key'] = apiKey
+  return app.request(path, { method: 'GET', headers }, TEST_ENV)
+}
+
+describe('GET /cuisines', () => {
+  beforeEach(() => {
+    vi.mocked(cuisineService.listCuisines).mockResolvedValue(SAMPLE_CUISINES)
+    vi.mocked(cuisineService.searchCuisines).mockResolvedValue([SAMPLE_CUISINES[0]])
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 200 with all cuisines when no query param', async () => {
+    const res = await request('/cuisines', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe(200)
+    expect(body.message).toBe('Cuisines retrieved')
+    expect(body.data).toEqual(SAMPLE_CUISINES)
+    expect(vi.mocked(cuisineService.listCuisines)).toHaveBeenCalledOnce()
+  })
+
+  it('returns all cuisines for empty query string', async () => {
+    const res = await request('/cuisines?query=', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Cuisines retrieved')
+    expect(vi.mocked(cuisineService.listCuisines)).toHaveBeenCalledOnce()
+    expect(vi.mocked(cuisineService.searchCuisines)).not.toHaveBeenCalled()
+  })
+
+  it('returns all cuisines for whitespace-only query', async () => {
+    const res = await request('/cuisines?query=   ', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Cuisines retrieved')
+    expect(vi.mocked(cuisineService.listCuisines)).toHaveBeenCalledOnce()
+    expect(vi.mocked(cuisineService.searchCuisines)).not.toHaveBeenCalled()
+  })
+
+  it('returns filtered cuisines for non-blank query', async () => {
+    vi.mocked(cuisineService.searchCuisines).mockResolvedValue([{ id: 1, name: 'Italian' }])
+    const res = await request('/cuisines?query=ital', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Cuisines queried')
+    expect(body.data).toEqual([{ id: 1, name: 'Italian' }])
+    expect(vi.mocked(cuisineService.searchCuisines)).toHaveBeenCalledWith(expect.anything(), 'ital')
+    expect(vi.mocked(cuisineService.listCuisines)).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 with empty array when no cuisines match query', async () => {
+    vi.mocked(cuisineService.searchCuisines).mockResolvedValue([])
+    const res = await request('/cuisines?query=zzz', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Cuisines queried')
+    expect(body.data).toEqual([])
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await request('/cuisines')
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/routes/cuisines.ts
+++ b/src/routes/cuisines.ts
@@ -1,0 +1,19 @@
+import { Hono } from 'hono'
+import { createDb } from '../db/client'
+import { buildSuccess } from '../lib/response'
+import { listCuisines, searchCuisines } from '../services/cuisineService'
+
+export const cuisineRouter = new Hono<{ Bindings: CloudflareBindings }>()
+
+cuisineRouter.get('/', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const query = c.req.query('query')
+
+  if (!query || !query.trim()) {
+    const data = await listCuisines(db)
+    return c.json(buildSuccess(200, 'Cuisines retrieved', data), 200)
+  }
+
+  const data = await searchCuisines(db, query)
+  return c.json(buildSuccess(200, 'Cuisines queried', data), 200)
+})

--- a/src/services/cuisineService.ts
+++ b/src/services/cuisineService.ts
@@ -1,0 +1,49 @@
+import { eq, ilike } from 'drizzle-orm'
+import { createDb } from '../db/client'
+import { cuisines, type Cuisine } from '../db/schema/cuisines'
+import { BadRequestError, NotFoundError } from '../errors'
+
+type Db = ReturnType<typeof createDb>
+
+export type CuisineResponse = { id: number; name: string }
+
+function toResponse(row: Cuisine): CuisineResponse {
+  return { id: row.id, name: row.name }
+}
+
+export async function listCuisines(db: Db): Promise<CuisineResponse[]> {
+  const rows = await db.select().from(cuisines)
+  return rows.map(toResponse)
+}
+
+export async function searchCuisines(db: Db, query: string): Promise<CuisineResponse[]> {
+  const rows = await db.select().from(cuisines).where(ilike(cuisines.name, `%${query}%`))
+  return rows.map(toResponse)
+}
+
+export async function resolveCuisine(db: Db, id?: number, name?: string): Promise<Cuisine> {
+  if (id == null && !name?.trim()) {
+    throw new BadRequestError('Cuisine request must have either an ID or a name.')
+  }
+
+  if (id != null) {
+    const [row] = await db.select().from(cuisines).where(eq(cuisines.id, id))
+    if (!row) throw new NotFoundError(`Cuisine ID not found: ${id}`)
+    return row
+  }
+
+  const [existing] = await db.select().from(cuisines).where(ilike(cuisines.name, name!))
+  if (existing) return existing
+
+  const [inserted] = await db
+    .insert(cuisines)
+    .values({ name: name! })
+    .onConflictDoNothing({ target: cuisines.name })
+    .returning()
+  if (inserted) return inserted
+
+  // Race condition: another request inserted the same name between our SELECT and INSERT.
+  // Re-fetch to get the row that won the conflict.
+  const [refetched] = await db.select().from(cuisines).where(ilike(cuisines.name, name!))
+  return refetched!
+}


### PR DESCRIPTION
Closes #8

## Summary
- Adds `GET /cuisines` endpoint with optional `?query=` search param
- Drizzle schema targeting the `recipeservice.cuisines` table
- Service layer with `listCuisines`, `searchCuisines`, and `resolveCuisine` (for use by Recipe later)
- Swaps `@neondatabase/serverless` for `postgres.js` — the Neon HTTP driver only works with Neon-hosted databases; this project uses Supabase

## Test plan
- [ ] `pnpm test` passes (33 tests)
- [x] `GET /cuisines` returns all cuisines against a running dev server
- [x] `GET /cuisines?query=ital` returns filtered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)