### PR TITLE
feat: add tags resource

### DIFF
--- a/.claude/agents/issue-scaffolder.md
+++ b/.claude/agents/issue-scaffolder.md
@@ -38,16 +38,16 @@ those slices depend on each other — not just listing files.
    may edit either the issues or the dependency map before saying yes.
 6. Only after confirmation:
    a. Ensure required labels exist (`migration`, `phase-1`…`phase-N`, `blocked`,
-      `blocking`). Create any missing ones via `gh label create`.
+   `blocking`). Create any missing ones via `gh label create`.
    b. Create issues one at a time via `gh issue create`. Capture each issue's number
-      and URL as you go.
+   and URL as you go.
    c. Apply blocking relationships using the GitHub GraphQL API. For each
-      "X blocked by Y" pair, fetch both issues' node IDs then call:
-      ```
-      gh api graphql -f query='mutation { addBlockedBy(input: { issueId: "<X_node_id>", blockingIssueId: "<Y_node_id>" }) { issue { number } } }'
-      ```
+   "X blocked by Y" pair, fetch both issues' node IDs then call:
+   ```
+   gh api graphql -f query='mutation { addBlockedBy(input: { issueId: "<X_node_id>", blockingIssueId: "<Y_node_id>" }) { issue { number } } }'
+   ```
    d. Add the `blocked` label to every issue that has at least one blocker, and the
-      `blocking` label to every issue that blocks at least one other.
+   `blocking` label to every issue that blocks at least one other.
    e. Report back a summary: issue numbers/URLs and the blocking relationships applied.
 
 ## Rules

--- a/.claude/agents/issue-updater.md
+++ b/.claude/agents/issue-updater.md
@@ -17,10 +17,13 @@ confirmation before writing anything.
 
 2. **Fetch current state.** For each affected issue, retrieve the current title, body,
    labels, assignees, milestone, and (if relevant) blocking relationships:
+
    ```
    gh issue view <number> --json number,title,body,labels,assignees,milestone,state
    ```
+
    For blocking relationships:
+
    ```
    gh api graphql -f query='{ repository(owner: "{owner}", name: "{repo}") { issue(number: <N>) { blockedBy(first: 20) { nodes { number title } } blocking(first: 20) { nodes { number title } } } } }'
    ```
@@ -29,8 +32,8 @@ confirmation before writing anything.
    each issue. For blocking relationships, show additions and removals as:
    - `+ #12 now blocks #15`
    - `- #12 no longer blocks #15`
-   For body edits, show the changed section only (not the full body) unless the body
-   is short.
+     For body edits, show the changed section only (not the full body) unless the body
+     is short.
 
 4. **Stop and wait for confirmation.** Do not apply anything until the user says yes.
    They may modify the proposal before confirming.
@@ -54,17 +57,17 @@ confirmation before writing anything.
 
 ## Supported update types
 
-| What to change | How to ask |
-|---|---|
-| Title | "rename #12 to …" |
-| Body (full replace or append) | "update the body of #12 to …" / "append … to #12" |
-| Labels | "add label `blocked` to #12", "remove `phase-1` from #8" |
-| Assignees | "assign #12 to @user" |
-| Milestone | "move #12 to milestone vX" |
-| State | "close #12", "reopen #15" |
-| Add blocking relationship | "#12 blocks #15" / "#15 is blocked by #12" |
-| Remove blocking relationship | "#12 no longer blocks #15" |
-| Bulk label/assignee update | "add `phase-2` to all issues in phase 2" |
+| What to change                | How to ask                                               |
+| ----------------------------- | -------------------------------------------------------- |
+| Title                         | "rename #12 to …"                                        |
+| Body (full replace or append) | "update the body of #12 to …" / "append … to #12"        |
+| Labels                        | "add label `blocked` to #12", "remove `phase-1` from #8" |
+| Assignees                     | "assign #12 to @user"                                    |
+| Milestone                     | "move #12 to milestone vX"                               |
+| State                         | "close #12", "reopen #15"                                |
+| Add blocking relationship     | "#12 blocks #15" / "#15 is blocked by #12"               |
+| Remove blocking relationship  | "#12 no longer blocks #15"                               |
+| Bulk label/assignee update    | "add `phase-2` to all issues in phase 2"                 |
 
 ## Rules
 

--- a/src/db/schema/tags.ts
+++ b/src/db/schema/tags.ts
@@ -1,0 +1,10 @@
+import { bigserial, pgSchema, varchar } from 'drizzle-orm/pg-core'
+
+const recipeservice = pgSchema('recipeservice')
+
+export const tags = recipeservice.table('tags', {
+  id: bigserial('tag_id', { mode: 'number' }).primaryKey(),
+  name: varchar('tag_name', { length: 100 }).notNull().unique(),
+})
+
+export type Tag = typeof tags.$inferSelect

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { authMiddleware } from './middleware/auth'
 import { errorHandler } from './middleware/errorHandler'
 import { rateLimiterMiddleware } from './middleware/rateLimiter'
 import { cuisineRouter } from './routes/cuisines'
+import { tagRouter } from './routes/tags'
 
 const app = new Hono<{ Bindings: CloudflareBindings }>()
 
@@ -14,5 +15,6 @@ app.use('*', authMiddleware)
 app.use('*', rateLimiterMiddleware)
 
 app.route('/cuisines', cuisineRouter)
+app.route('/tags', tagRouter)
 
 export default app

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,1 @@
+export type NamedEntityResponse = { id: number; name: string }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -13,8 +13,7 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: CloudflareBindings }>
   const userKey = c.env.USER_API_KEY
   const adminKey = c.env.ADMIN_API_KEY
 
-  const isAdminRoute =
-    c.req.method === 'DELETE' && ADMIN_ROUTE_REGEX.test(c.req.path)
+  const isAdminRoute = c.req.method === 'DELETE' && ADMIN_ROUTE_REGEX.test(c.req.path)
 
   if (apiKey) {
     if (isAdminRoute && apiKey === adminKey) {

--- a/src/routes/tags.test.ts
+++ b/src/routes/tags.test.ts
@@ -1,0 +1,106 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authMiddleware } from '../middleware/auth'
+import * as tagService from '../services/tagService'
+import { tagRouter } from './tags'
+
+vi.mock('../db/client', () => ({ createDb: vi.fn(() => ({})) }))
+vi.mock('../services/tagService')
+
+type TestBindings = {
+  USER_API_KEY: string
+  ADMIN_API_KEY: string
+  DATABASE_URL: string
+}
+
+const USER_KEY = 'test-user-key'
+const ADMIN_KEY = 'test-admin-key'
+const TEST_ENV: TestBindings = {
+  USER_API_KEY: USER_KEY,
+  ADMIN_API_KEY: ADMIN_KEY,
+  DATABASE_URL: 'postgresql://test',
+}
+
+const SAMPLE_TAGS = [
+  { id: 1, name: 'Vegan' },
+  { id: 2, name: 'Gluten-Free' },
+]
+
+function buildTestApp() {
+  const app = new Hono<{ Bindings: TestBindings }>()
+  app.use('*', authMiddleware)
+  app.route('/tags', tagRouter)
+  return app
+}
+
+const app = buildTestApp()
+
+function request(path: string, apiKey?: string) {
+  const headers: Record<string, string> = {}
+  if (apiKey !== undefined) headers['X-Api-Key'] = apiKey
+  return app.request(path, { method: 'GET', headers }, TEST_ENV)
+}
+
+describe('GET /tags', () => {
+  beforeEach(() => {
+    vi.mocked(tagService.listTags).mockResolvedValue(SAMPLE_TAGS)
+    vi.mocked(tagService.searchTags).mockResolvedValue([SAMPLE_TAGS[0]])
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 200 with all tags when no query param', async () => {
+    const res = await request('/tags', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe(200)
+    expect(body.message).toBe('Tags retrieved')
+    expect(body.data).toEqual(SAMPLE_TAGS)
+    expect(vi.mocked(tagService.listTags)).toHaveBeenCalledOnce()
+  })
+
+  it('returns all tags for empty query string', async () => {
+    const res = await request('/tags?query=', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Tags retrieved')
+    expect(vi.mocked(tagService.listTags)).toHaveBeenCalledOnce()
+    expect(vi.mocked(tagService.searchTags)).not.toHaveBeenCalled()
+  })
+
+  it('returns all tags for whitespace-only query', async () => {
+    const res = await request('/tags?query=   ', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Tags retrieved')
+    expect(vi.mocked(tagService.listTags)).toHaveBeenCalledOnce()
+    expect(vi.mocked(tagService.searchTags)).not.toHaveBeenCalled()
+  })
+
+  it('returns filtered tags for non-blank query', async () => {
+    vi.mocked(tagService.searchTags).mockResolvedValue([{ id: 1, name: 'Vegan' }])
+    const res = await request('/tags?query=veg', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Tags queried')
+    expect(body.data).toEqual([{ id: 1, name: 'Vegan' }])
+    expect(vi.mocked(tagService.searchTags)).toHaveBeenCalledWith(expect.anything(), 'veg')
+    expect(vi.mocked(tagService.listTags)).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 with empty array when no tags match query', async () => {
+    vi.mocked(tagService.searchTags).mockResolvedValue([])
+    const res = await request('/tags?query=zzz', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Tags queried')
+    expect(body.data).toEqual([])
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await request('/tags')
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/routes/tags.ts
+++ b/src/routes/tags.ts
@@ -1,0 +1,19 @@
+import { Hono } from 'hono'
+import { createDb } from '../db/client'
+import { buildSuccess } from '../lib/response'
+import { listTags, searchTags } from '../services/tagService'
+
+export const tagRouter = new Hono<{ Bindings: CloudflareBindings }>()
+
+tagRouter.get('/', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const query = c.req.query('query')
+
+  if (!query || !query.trim()) {
+    const data = await listTags(db)
+    return c.json(buildSuccess(200, 'Tags retrieved', data), 200)
+  }
+
+  const data = await searchTags(db, query)
+  return c.json(buildSuccess(200, 'Tags queried', data), 200)
+})

--- a/src/services/cuisineService.ts
+++ b/src/services/cuisineService.ts
@@ -2,22 +2,24 @@ import { eq, ilike } from 'drizzle-orm'
 import { createDb } from '../db/client'
 import { cuisines, type Cuisine } from '../db/schema/cuisines'
 import { BadRequestError, NotFoundError } from '../errors'
+import type { NamedEntityResponse } from '../lib/types'
 
 type Db = ReturnType<typeof createDb>
 
-export type CuisineResponse = { id: number; name: string }
-
-function toResponse(row: Cuisine): CuisineResponse {
+function toResponse(row: Cuisine): NamedEntityResponse {
   return { id: row.id, name: row.name }
 }
 
-export async function listCuisines(db: Db): Promise<CuisineResponse[]> {
+export async function listCuisines(db: Db): Promise<NamedEntityResponse[]> {
   const rows = await db.select().from(cuisines)
   return rows.map(toResponse)
 }
 
-export async function searchCuisines(db: Db, query: string): Promise<CuisineResponse[]> {
-  const rows = await db.select().from(cuisines).where(ilike(cuisines.name, `%${query}%`))
+export async function searchCuisines(db: Db, query: string): Promise<NamedEntityResponse[]> {
+  const rows = await db
+    .select()
+    .from(cuisines)
+    .where(ilike(cuisines.name, `%${query}%`))
   return rows.map(toResponse)
 }
 

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -1,0 +1,51 @@
+import { eq, ilike } from 'drizzle-orm'
+import { createDb } from '../db/client'
+import { tags, type Tag } from '../db/schema/tags'
+import { BadRequestError, NotFoundError } from '../errors'
+import type { NamedEntityResponse } from '../lib/types'
+
+type Db = ReturnType<typeof createDb>
+
+function toResponse(row: Tag): NamedEntityResponse {
+  return { id: row.id, name: row.name }
+}
+
+export async function listTags(db: Db): Promise<NamedEntityResponse[]> {
+  const rows = await db.select().from(tags)
+  return rows.map(toResponse)
+}
+
+export async function searchTags(db: Db, query: string): Promise<NamedEntityResponse[]> {
+  const rows = await db
+    .select()
+    .from(tags)
+    .where(ilike(tags.name, `%${query}%`))
+  return rows.map(toResponse)
+}
+
+export async function resolveTag(db: Db, id?: number, name?: string): Promise<Tag> {
+  if (id == null && !name?.trim()) {
+    throw new BadRequestError('Tag request must have either an ID or a name.')
+  }
+
+  if (id != null) {
+    const [row] = await db.select().from(tags).where(eq(tags.id, id))
+    if (!row) throw new NotFoundError(`Tag ID not found: ${id}`)
+    return row
+  }
+
+  const [existing] = await db.select().from(tags).where(ilike(tags.name, name!))
+  if (existing) return existing
+
+  const [inserted] = await db
+    .insert(tags)
+    .values({ name: name! })
+    .onConflictDoNothing({ target: tags.name })
+    .returning()
+  if (inserted) return inserted
+
+  // Race condition: another request inserted the same name between our SELECT and INSERT.
+  // Re-fetch to get the row that won the conflict.
+  const [refetched] = await db.select().from(tags).where(ilike(tags.name, name!))
+  return refetched!
+}


### PR DESCRIPTION
Closes #9

## Summary
- Adds `src/db/schema/tags.ts` — `tag_id` (bigserial PK), `tag_name` (varchar 100, unique, not null), matching the existing DB table
- Adds `src/services/tagService.ts` — `listTags`, `searchTags`, `resolveTag` following the cuisine pattern; fixes the `isTagValid` NPE bug from the Java source
- Adds `GET /tags` route with query param search fallback (blank/whitespace → full list)
- Extracts `NamedEntityResponse` into `src/lib/types.ts` and updates `cuisineService.ts` to use it, eliminating the duplicate inline type

## Test plan
- [x] `pnpm test` passes (39 tests)
- [x] `pnpm lint` and `pnpm run format:check` pass
- [x] Manually verify `GET /tags` and `GET /tags?query=<string>` against running dev server
- [ ] Confirm `drizzle-kit push` is a no-op once the pre-existing drizzle-kit check-constraint bug is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)