### PR TITLE
feat: add Unit resource

### DIFF
--- a/src/db/schema/units.ts
+++ b/src/db/schema/units.ts
@@ -1,0 +1,11 @@
+import { bigserial, pgSchema, varchar } from 'drizzle-orm/pg-core'
+
+const recipeservice = pgSchema('recipeservice')
+
+export const units = recipeservice.table('units', {
+  id: bigserial('unit_id', { mode: 'number' }).primaryKey(),
+  name: varchar('unit_name', { length: 50 }).notNull().unique(),
+  abbreviation: varchar('abbreviation', { length: 10 }),
+})
+
+export type Unit = typeof units.$inferSelect

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { errorHandler } from './middleware/errorHandler'
 import { rateLimiterMiddleware } from './middleware/rateLimiter'
 import { cuisineRouter } from './routes/cuisines'
 import { tagRouter } from './routes/tags'
+import { unitRouter } from './routes/units'
 
 const app = new Hono<{ Bindings: CloudflareBindings }>()
 
@@ -16,5 +17,6 @@ app.use('*', rateLimiterMiddleware)
 
 app.route('/cuisines', cuisineRouter)
 app.route('/tags', tagRouter)
+app.route('/units', unitRouter)
 
 export default app

--- a/src/routes/units.test.ts
+++ b/src/routes/units.test.ts
@@ -1,0 +1,75 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authMiddleware } from '../middleware/auth'
+import * as unitService from '../services/unitService'
+import { unitRouter } from './units'
+
+vi.mock('../db/client', () => ({ createDb: vi.fn(() => ({})) }))
+vi.mock('../services/unitService')
+
+type TestBindings = {
+  USER_API_KEY: string
+  ADMIN_API_KEY: string
+  DATABASE_URL: string
+}
+
+const USER_KEY = 'test-user-key'
+const ADMIN_KEY = 'test-admin-key'
+const TEST_ENV: TestBindings = {
+  USER_API_KEY: USER_KEY,
+  ADMIN_API_KEY: ADMIN_KEY,
+  DATABASE_URL: 'postgresql://test',
+}
+
+const SAMPLE_UNITS = [
+  { id: 1, name: 'Cup', abbreviation: 'c' },
+  { id: 2, name: 'Tablespoon', abbreviation: 'tbsp' },
+  { id: 3, name: 'Piece', abbreviation: null },
+]
+
+function buildTestApp() {
+  const app = new Hono<{ Bindings: TestBindings }>()
+  app.use('*', authMiddleware)
+  app.route('/units', unitRouter)
+  return app
+}
+
+const app = buildTestApp()
+
+function request(path: string, apiKey?: string) {
+  const headers: Record<string, string> = {}
+  if (apiKey !== undefined) headers['X-Api-Key'] = apiKey
+  return app.request(path, { method: 'GET', headers }, TEST_ENV)
+}
+
+describe('GET /units', () => {
+  beforeEach(() => {
+    vi.mocked(unitService.listUnits).mockResolvedValue(SAMPLE_UNITS)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 200 with all units', async () => {
+    const res = await request('/units', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe(200)
+    expect(body.message).toBe('Units retrieved')
+    expect(body.data).toEqual(SAMPLE_UNITS)
+    expect(vi.mocked(unitService.listUnits)).toHaveBeenCalledOnce()
+  })
+
+  it('includes null abbreviation in response', async () => {
+    const res = await request('/units', USER_KEY)
+    const body = await res.json()
+    const piece = body.data.find((u: { id: number }) => u.id === 3)
+    expect(piece.abbreviation).toBeNull()
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await request('/units')
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/routes/units.ts
+++ b/src/routes/units.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono'
+import { createDb } from '../db/client'
+import { buildSuccess } from '../lib/response'
+import { listUnits } from '../services/unitService'
+
+export const unitRouter = new Hono<{ Bindings: CloudflareBindings }>()
+
+unitRouter.get('/', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const data = await listUnits(db)
+  return c.json(buildSuccess(200, 'Units retrieved', data), 200)
+})

--- a/src/services/unitService.ts
+++ b/src/services/unitService.ts
@@ -1,0 +1,23 @@
+import { eq } from 'drizzle-orm'
+import { createDb } from '../db/client'
+import { units, type Unit } from '../db/schema/units'
+import { NotFoundError } from '../errors'
+
+type Db = ReturnType<typeof createDb>
+
+export type UnitResponse = { id: number; name: string; abbreviation: string | null }
+
+function toResponse(row: Unit): UnitResponse {
+  return { id: row.id, name: row.name, abbreviation: row.abbreviation ?? null }
+}
+
+export async function listUnits(db: Db): Promise<UnitResponse[]> {
+  const rows = await db.select().from(units)
+  return rows.map(toResponse)
+}
+
+export async function resolveUnit(db: Db, id: number): Promise<Unit> {
+  const [row] = await db.select().from(units).where(eq(units.id, id))
+  if (!row) throw new NotFoundError(`Unit ID not found: ${id}`)
+  return row
+}


### PR DESCRIPTION
## Summary
- Adds `GET /units` (200, no search param) matching the Spring Boot controller
- Drizzle schema with `unit_id` (bigserial PK), `unit_name` (varchar 50, unique, not null), `abbreviation` (varchar 10, nullable)
- `listUnits` and `resolveUnit(db, id)` service functions — `resolveUnit` throws 404, never auto-creates
- Response shape: `{ id, name, abbreviation }` with `abbreviation: null` when absent (not omitted)

## Test plan
- [x] `GET /units` returns 200 with all units
- [x] `abbreviation` is `null` (not omitted) when absent
- [x] Returns 401 without API key
- [x] `pnpm test` passes (42 tests)
- [x] `pnpm lint` passes

Note: `drizzle-kit push` fails with a TypeError on a CHECK constraint — confirmed pre-existing bug on `main` before this PR's changes.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)