### PR TITLE
feat: add ingredients resource

### DIFF
--- a/src/db/schema/ingredients.ts
+++ b/src/db/schema/ingredients.ts
@@ -1,0 +1,11 @@
+import { bigserial, pgSchema, varchar } from 'drizzle-orm/pg-core'
+
+const recipeservice = pgSchema('recipeservice')
+
+export const ingredients = recipeservice.table('ingredients', {
+  id: bigserial('ingredient_id', { mode: 'number' }).primaryKey(),
+  // ingredient_name is never updated after creation (mirrors updatable=false in the Java entity)
+  name: varchar('ingredient_name', { length: 255 }).notNull().unique(),
+})
+
+export type Ingredient = typeof ingredients.$inferSelect

--- a/src/db/schema/units.ts
+++ b/src/db/schema/units.ts
@@ -1,0 +1,11 @@
+import { bigserial, pgSchema, varchar } from 'drizzle-orm/pg-core'
+
+const recipeservice = pgSchema('recipeservice')
+
+export const units = recipeservice.table('units', {
+  id: bigserial('unit_id', { mode: 'number' }).primaryKey(),
+  name: varchar('unit_name', { length: 50 }).notNull().unique(),
+  abbreviation: varchar('abbreviation', { length: 10 }),
+})
+
+export type Unit = typeof units.$inferSelect

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { authMiddleware } from './middleware/auth'
 import { errorHandler } from './middleware/errorHandler'
 import { rateLimiterMiddleware } from './middleware/rateLimiter'
 import { cuisineRouter } from './routes/cuisines'
+import { ingredientRouter } from './routes/ingredients'
 import { tagRouter } from './routes/tags'
 import { unitRouter } from './routes/units'
 
@@ -16,6 +17,7 @@ app.use('*', authMiddleware)
 app.use('*', rateLimiterMiddleware)
 
 app.route('/cuisines', cuisineRouter)
+app.route('/ingredients', ingredientRouter)
 app.route('/tags', tagRouter)
 app.route('/units', unitRouter)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { errorHandler } from './middleware/errorHandler'
 import { rateLimiterMiddleware } from './middleware/rateLimiter'
 import { cuisineRouter } from './routes/cuisines'
 import { tagRouter } from './routes/tags'
+import { unitRouter } from './routes/units'
 
 const app = new Hono<{ Bindings: CloudflareBindings }>()
 
@@ -16,5 +17,6 @@ app.use('*', rateLimiterMiddleware)
 
 app.route('/cuisines', cuisineRouter)
 app.route('/tags', tagRouter)
+app.route('/units', unitRouter)
 
 export default app

--- a/src/routes/ingredients.test.ts
+++ b/src/routes/ingredients.test.ts
@@ -1,0 +1,109 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authMiddleware } from '../middleware/auth'
+import * as ingredientService from '../services/ingredientService'
+import { ingredientRouter } from './ingredients'
+
+vi.mock('../db/client', () => ({ createDb: vi.fn(() => ({})) }))
+vi.mock('../services/ingredientService')
+
+type TestBindings = {
+  USER_API_KEY: string
+  ADMIN_API_KEY: string
+  DATABASE_URL: string
+}
+
+const USER_KEY = 'test-user-key'
+const ADMIN_KEY = 'test-admin-key'
+const TEST_ENV: TestBindings = {
+  USER_API_KEY: USER_KEY,
+  ADMIN_API_KEY: ADMIN_KEY,
+  DATABASE_URL: 'postgresql://test',
+}
+
+const SAMPLE_INGREDIENTS = [
+  { id: 1, name: 'Garlic' },
+  { id: 2, name: 'Onion' },
+]
+
+function buildTestApp() {
+  const app = new Hono<{ Bindings: TestBindings }>()
+  app.use('*', authMiddleware)
+  app.route('/ingredients', ingredientRouter)
+  return app
+}
+
+const app = buildTestApp()
+
+function request(path: string, apiKey?: string) {
+  const headers: Record<string, string> = {}
+  if (apiKey !== undefined) headers['X-Api-Key'] = apiKey
+  return app.request(path, { method: 'GET', headers }, TEST_ENV)
+}
+
+describe('GET /ingredients', () => {
+  beforeEach(() => {
+    vi.mocked(ingredientService.listIngredients).mockResolvedValue(SAMPLE_INGREDIENTS)
+    vi.mocked(ingredientService.searchIngredients).mockResolvedValue([SAMPLE_INGREDIENTS[0]])
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 200 with all ingredients when no query param', async () => {
+    const res = await request('/ingredients', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe(200)
+    expect(body.message).toBe('Ingredients retrieved')
+    expect(body.data).toEqual(SAMPLE_INGREDIENTS)
+    expect(vi.mocked(ingredientService.listIngredients)).toHaveBeenCalledOnce()
+  })
+
+  it('returns all ingredients for empty query string', async () => {
+    const res = await request('/ingredients?query=', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Ingredients retrieved')
+    expect(vi.mocked(ingredientService.listIngredients)).toHaveBeenCalledOnce()
+    expect(vi.mocked(ingredientService.searchIngredients)).not.toHaveBeenCalled()
+  })
+
+  it('returns all ingredients for whitespace-only query', async () => {
+    const res = await request('/ingredients?query=   ', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Ingredients retrieved')
+    expect(vi.mocked(ingredientService.listIngredients)).toHaveBeenCalledOnce()
+    expect(vi.mocked(ingredientService.searchIngredients)).not.toHaveBeenCalled()
+  })
+
+  it('returns filtered ingredients for non-blank query', async () => {
+    vi.mocked(ingredientService.searchIngredients).mockResolvedValue([{ id: 1, name: 'Garlic' }])
+    const res = await request('/ingredients?query=gar', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Ingredients queried')
+    expect(body.data).toEqual([{ id: 1, name: 'Garlic' }])
+    expect(vi.mocked(ingredientService.searchIngredients)).toHaveBeenCalledWith(
+      expect.anything(),
+      'gar',
+    )
+    expect(vi.mocked(ingredientService.listIngredients)).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 with empty array when no ingredients match query', async () => {
+    vi.mocked(ingredientService.searchIngredients).mockResolvedValue([])
+    const res = await request('/ingredients?query=zzz', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Ingredients queried')
+    expect(body.data).toEqual([])
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await request('/ingredients')
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/routes/ingredients.ts
+++ b/src/routes/ingredients.ts
@@ -1,0 +1,19 @@
+import { Hono } from 'hono'
+import { createDb } from '../db/client'
+import { buildSuccess } from '../lib/response'
+import { listIngredients, searchIngredients } from '../services/ingredientService'
+
+export const ingredientRouter = new Hono<{ Bindings: CloudflareBindings }>()
+
+ingredientRouter.get('/', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const query = c.req.query('query')
+
+  if (!query || !query.trim()) {
+    const data = await listIngredients(db)
+    return c.json(buildSuccess(200, 'Ingredients retrieved', data), 200)
+  }
+
+  const data = await searchIngredients(db, query)
+  return c.json(buildSuccess(200, 'Ingredients queried', data), 200)
+})

--- a/src/routes/units.test.ts
+++ b/src/routes/units.test.ts
@@ -1,0 +1,75 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authMiddleware } from '../middleware/auth'
+import * as unitService from '../services/unitService'
+import { unitRouter } from './units'
+
+vi.mock('../db/client', () => ({ createDb: vi.fn(() => ({})) }))
+vi.mock('../services/unitService')
+
+type TestBindings = {
+  USER_API_KEY: string
+  ADMIN_API_KEY: string
+  DATABASE_URL: string
+}
+
+const USER_KEY = 'test-user-key'
+const ADMIN_KEY = 'test-admin-key'
+const TEST_ENV: TestBindings = {
+  USER_API_KEY: USER_KEY,
+  ADMIN_API_KEY: ADMIN_KEY,
+  DATABASE_URL: 'postgresql://test',
+}
+
+const SAMPLE_UNITS = [
+  { id: 1, name: 'Cup', abbreviation: 'c' },
+  { id: 2, name: 'Tablespoon', abbreviation: 'tbsp' },
+  { id: 3, name: 'Piece', abbreviation: null },
+]
+
+function buildTestApp() {
+  const app = new Hono<{ Bindings: TestBindings }>()
+  app.use('*', authMiddleware)
+  app.route('/units', unitRouter)
+  return app
+}
+
+const app = buildTestApp()
+
+function request(path: string, apiKey?: string) {
+  const headers: Record<string, string> = {}
+  if (apiKey !== undefined) headers['X-Api-Key'] = apiKey
+  return app.request(path, { method: 'GET', headers }, TEST_ENV)
+}
+
+describe('GET /units', () => {
+  beforeEach(() => {
+    vi.mocked(unitService.listUnits).mockResolvedValue(SAMPLE_UNITS)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 200 with all units', async () => {
+    const res = await request('/units', USER_KEY)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe(200)
+    expect(body.message).toBe('Units retrieved')
+    expect(body.data).toEqual(SAMPLE_UNITS)
+    expect(vi.mocked(unitService.listUnits)).toHaveBeenCalledOnce()
+  })
+
+  it('includes null abbreviation in response', async () => {
+    const res = await request('/units', USER_KEY)
+    const body = await res.json()
+    const piece = body.data.find((u: { id: number }) => u.id === 3)
+    expect(piece.abbreviation).toBeNull()
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await request('/units')
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/routes/units.ts
+++ b/src/routes/units.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono'
+import { createDb } from '../db/client'
+import { buildSuccess } from '../lib/response'
+import { listUnits } from '../services/unitService'
+
+export const unitRouter = new Hono<{ Bindings: CloudflareBindings }>()
+
+unitRouter.get('/', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const data = await listUnits(db)
+  return c.json(buildSuccess(200, 'Units retrieved', data), 200)
+})

--- a/src/services/ingredientService.ts
+++ b/src/services/ingredientService.ts
@@ -1,0 +1,52 @@
+import { eq, ilike } from 'drizzle-orm'
+import { createDb } from '../db/client'
+import { ingredients, type Ingredient } from '../db/schema/ingredients'
+import { BadRequestError, NotFoundError } from '../errors'
+import type { NamedEntityResponse } from '../lib/types'
+
+type Db = ReturnType<typeof createDb>
+
+function toResponse(row: Ingredient): NamedEntityResponse {
+  return { id: row.id, name: row.name }
+}
+
+export async function listIngredients(db: Db): Promise<NamedEntityResponse[]> {
+  const rows = await db.select().from(ingredients)
+  return rows.map(toResponse)
+}
+
+export async function searchIngredients(db: Db, query: string): Promise<NamedEntityResponse[]> {
+  const rows = await db
+    .select()
+    .from(ingredients)
+    .where(ilike(ingredients.name, `%${query}%`))
+  return rows.map(toResponse)
+}
+
+export async function resolveIngredient(db: Db, id?: number, name?: string): Promise<Ingredient> {
+  if (id == null && !name?.trim()) {
+    throw new BadRequestError('Ingredient request must have either an ID or a name.')
+  }
+
+  if (id != null) {
+    const [row] = await db.select().from(ingredients).where(eq(ingredients.id, id))
+    if (!row) throw new NotFoundError(`Ingredient ID not found: ${id}`)
+    return row
+  }
+
+  const [existing] = await db.select().from(ingredients).where(ilike(ingredients.name, name!))
+  if (existing) return existing
+
+  // ingredient_name is never updated after insertion — this is the only place it is written
+  const [inserted] = await db
+    .insert(ingredients)
+    .values({ name: name! })
+    .onConflictDoNothing({ target: ingredients.name })
+    .returning()
+  if (inserted) return inserted
+
+  // Race condition: another request inserted the same name between our SELECT and INSERT.
+  // Re-fetch to get the row that won the conflict.
+  const [refetched] = await db.select().from(ingredients).where(ilike(ingredients.name, name!))
+  return refetched!
+}

--- a/src/services/unitService.ts
+++ b/src/services/unitService.ts
@@ -1,0 +1,23 @@
+import { eq } from 'drizzle-orm'
+import { createDb } from '../db/client'
+import { units, type Unit } from '../db/schema/units'
+import { NotFoundError } from '../errors'
+
+type Db = ReturnType<typeof createDb>
+
+export type UnitResponse = { id: number; name: string; abbreviation: string | null }
+
+function toResponse(row: Unit): UnitResponse {
+  return { id: row.id, name: row.name, abbreviation: row.abbreviation ?? null }
+}
+
+export async function listUnits(db: Db): Promise<UnitResponse[]> {
+  const rows = await db.select().from(units)
+  return rows.map(toResponse)
+}
+
+export async function resolveUnit(db: Db, id: number): Promise<Unit> {
+  const [row] = await db.select().from(units).where(eq(units.id, id))
+  if (!row) throw new NotFoundError(`Unit ID not found: ${id}`)
+  return row
+}


### PR DESCRIPTION
## Summary
- Drizzle schema for `recipeservice.ingredients` (`ingredient_id` bigserial PK, `ingredient_name` varchar(255) not null unique)
- `GET /ingredients` — returns all ingredients; `GET /ingredients?query=` — case-insensitive contains search; blank/whitespace falls back to full list
- `resolveIngredient` service method: lookup by ID (404 if not found) or find-or-create by name; throws 400 if neither provided
- `ingredient_name` is never updated after insertion (mirrors `updatable=false` in the Java entity); enforced by convention with a comment at the insertion point

## Test plan
- [x] All 48 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm run lint`)
- [x] `GET /ingredients` returns 200 with full list
- [x] `GET /ingredients?query=gar` returns case-insensitive matches
- [x] `GET /ingredients?query=` returns full list (blank fallback)
- [x] Manually verify against running dev server

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)