### PR TITLE
feat: add Recipe CRUD endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { cuisineRouter } from './routes/cuisines'
 import { ingredientRouter } from './routes/ingredients'
 import { tagRouter } from './routes/tags'
 import { unitRouter } from './routes/units'
+import { recipeRouter } from './routes/recipes'
 
 const app = new Hono<{ Bindings: CloudflareBindings }>()
 
@@ -20,5 +21,6 @@ app.route('/cuisines', cuisineRouter)
 app.route('/ingredients', ingredientRouter)
 app.route('/tags', tagRouter)
 app.route('/units', unitRouter)
+app.route('/recipes', recipeRouter)
 
 export default app

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -1,0 +1,308 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authMiddleware } from '../middleware/auth'
+import { errorHandler } from '../middleware/errorHandler'
+import { NotFoundError } from '../errors'
+import * as recipeService from '../services/recipeService'
+import { recipeRouter } from './recipes'
+
+vi.mock('../db/client', () => ({ createDb: vi.fn(() => ({})) }))
+vi.mock('../services/recipeService')
+
+type TestBindings = {
+  USER_API_KEY: string
+  ADMIN_API_KEY: string
+  DATABASE_URL: string
+}
+
+const USER_KEY = 'test-user-key'
+const ADMIN_KEY = 'test-admin-key'
+const TEST_ENV: TestBindings = {
+  USER_API_KEY: USER_KEY,
+  ADMIN_API_KEY: ADMIN_KEY,
+  DATABASE_URL: 'postgresql://test',
+}
+
+const SAMPLE_LIST_ITEMS: recipeService.RecipeListItem[] = [
+  { id: 1, name: 'Pasta', imageUrl: 'https://example.com/pasta.jpg' },
+  { id: 2, name: 'Salad', imageUrl: null },
+]
+
+const FULL_RECIPE: recipeService.RecipeResponse = {
+  id: 1,
+  name: 'Pasta',
+  description: 'A simple pasta dish',
+  cuisine: { id: 1, name: 'Italian' },
+  author: 'Chef Mario',
+  calories: 450,
+  servings: 2,
+  cookingTime: 10,
+  preparationTime: 5,
+  imageUrl: 'https://example.com/pasta.jpg',
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  updatedAt: new Date('2024-01-01T00:00:00Z'),
+  ingredients: [
+    {
+      id: 10,
+      name: 'Spaghetti',
+      unitId: 1,
+      unitName: 'Gram',
+      abbreviation: 'g',
+      quantity: 200,
+      notes: null,
+    },
+  ],
+  tags: [{ recipeTagId: 1, id: 5, name: 'Quick' }],
+  steps: [{ stepId: 1, stepNumber: 1, description: 'Boil water', tip: null, imageUrl: null }],
+}
+
+const SAVE_BODY = {
+  name: 'Pasta',
+  description: 'A simple pasta dish',
+  servings: 2,
+  cookingTime: 10,
+  preparationTime: 5,
+  cuisine: { name: 'Italian' },
+  ingredients: [{ name: 'Spaghetti', unitId: 1, quantity: 200 }],
+  steps: [{ stepNumber: 1, description: 'Boil water' }],
+}
+
+function buildTestApp() {
+  const app = new Hono<{ Bindings: TestBindings }>()
+  app.onError(errorHandler)
+  app.use('*', authMiddleware)
+  app.route('/recipes', recipeRouter)
+  return app
+}
+
+const app = buildTestApp()
+
+function request(
+  path: string,
+  options: { method?: string; body?: unknown; apiKey?: string | null } = {},
+) {
+  const { method = 'GET', body, apiKey = USER_KEY } = options
+  const headers: Record<string, string> = {}
+  if (apiKey != null) headers['X-Api-Key'] = apiKey
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return app.request(
+    path,
+    {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    },
+    TEST_ENV,
+  )
+}
+
+describe('GET /recipes', () => {
+  beforeEach(() => {
+    vi.mocked(recipeService.listRecipes).mockResolvedValue(SAMPLE_LIST_ITEMS)
+  })
+
+  afterEach(() => vi.clearAllMocks())
+
+  it('returns 200 with paginated slim list', async () => {
+    const res = await request('/recipes')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe(200)
+    expect(body.message).toBe('Recipes retrieved')
+    expect(body.data).toEqual(SAMPLE_LIST_ITEMS)
+    expect(vi.mocked(recipeService.listRecipes)).toHaveBeenCalledWith(expect.anything(), 0, 12)
+  })
+
+  it('passes custom page and limit params', async () => {
+    const res = await request('/recipes?page=2&limit=5')
+    expect(res.status).toBe(200)
+    expect(vi.mocked(recipeService.listRecipes)).toHaveBeenCalledWith(expect.anything(), 2, 5)
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await request('/recipes', { apiKey: null })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('POST /recipes', () => {
+  beforeEach(() => {
+    vi.mocked(recipeService.createRecipe).mockResolvedValue(FULL_RECIPE)
+  })
+
+  afterEach(() => vi.clearAllMocks())
+
+  it('returns 201 with full response and Location header', async () => {
+    const res = await request('/recipes', { method: 'POST', body: SAVE_BODY })
+    expect(res.status).toBe(201)
+    expect(res.headers.get('Location')).toBe('/recipes/1')
+    const body = await res.json()
+    expect(body.status).toBe(201)
+    expect(body.message).toBe('Recipe saved')
+    expect(body.data.id).toBe(1)
+    expect(body.data.cuisine).toEqual({ id: 1, name: 'Italian' })
+    expect(body.data.ingredients).toHaveLength(1)
+    expect(body.data.steps).toHaveLength(1)
+  })
+
+  it('returns 400 when name is too short', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, name: 'A' },
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toBe('Recipe name must be between 2 to 150 characters.')
+  })
+
+  it('returns 400 when servings is zero', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, servings: 0 },
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toBe('Servings must be a more than zero.')
+  })
+
+  it('returns 400 when cookingTime is negative', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, cookingTime: -1 },
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toBe('Cooking time cannot be negative.')
+  })
+
+  it('returns 400 when preparationTime is zero', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, preparationTime: 0 },
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toBe('Preparation time cannot be zero minutes.')
+  })
+
+  it('returns 400 when ingredients array is empty', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, ingredients: [] },
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toBe('There must be at least one ingredient.')
+  })
+
+  it('returns 400 when steps array is empty', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, steps: [] },
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toBe('There must be at least one step.')
+  })
+
+  it('propagates 404 from service when unit is not found', async () => {
+    vi.mocked(recipeService.createRecipe).mockRejectedValue(
+      new NotFoundError('Unit ID not found: 999'),
+    )
+    const res = await request('/recipes', { method: 'POST', body: SAVE_BODY })
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.message).toBe('Unit ID not found: 999')
+  })
+})
+
+describe('GET /recipes/:id', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('returns 200 with full recipe response', async () => {
+    vi.mocked(recipeService.getRecipe).mockResolvedValue(FULL_RECIPE)
+    const res = await request('/recipes/1')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe(200)
+    expect(body.message).toBe('Recipe retrieved')
+    expect(body.data.id).toBe(1)
+    expect(body.data.tags).toEqual([{ recipeTagId: 1, id: 5, name: 'Quick' }])
+    expect(body.data.steps[0].stepId).toBe(1)
+    expect(body.data.steps[0].imageUrl).toBeNull()
+  })
+
+  it('returns 404 when recipe does not exist', async () => {
+    vi.mocked(recipeService.getRecipe).mockRejectedValue(
+      new NotFoundError('Recipe not found with id: 999'),
+    )
+    const res = await request('/recipes/999')
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.message).toBe('Recipe not found with id: 999')
+  })
+})
+
+describe('PATCH /recipes/:id', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('returns 200 with updated full response', async () => {
+    const updated = { ...FULL_RECIPE, name: 'Updated Pasta' }
+    vi.mocked(recipeService.updateRecipe).mockResolvedValue(updated)
+    const res = await request('/recipes/1', { method: 'PATCH', body: { name: 'Updated Pasta' } })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Recipe updated')
+    expect(body.data.name).toBe('Updated Pasta')
+  })
+
+  it('passes only provided fields to service', async () => {
+    vi.mocked(recipeService.updateRecipe).mockResolvedValue(FULL_RECIPE)
+    await request('/recipes/1', { method: 'PATCH', body: { calories: null } })
+    expect(vi.mocked(recipeService.updateRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      1,
+      expect.objectContaining({ calories: null }),
+    )
+  })
+
+  it('returns 404 when recipe does not exist', async () => {
+    vi.mocked(recipeService.updateRecipe).mockRejectedValue(
+      new NotFoundError('Recipe not found with id: 999'),
+    )
+    const res = await request('/recipes/999', { method: 'PATCH', body: { name: 'New Name' } })
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('DELETE /recipes/:id', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('returns 204 with admin key', async () => {
+    vi.mocked(recipeService.deleteRecipe).mockResolvedValue(undefined)
+    const res = await request('/recipes/1', { method: 'DELETE', apiKey: ADMIN_KEY })
+    expect(res.status).toBe(204)
+    expect(vi.mocked(recipeService.deleteRecipe)).toHaveBeenCalledWith(expect.anything(), 1)
+  })
+
+  it('returns 401 without admin key (user key is rejected)', async () => {
+    const res = await request('/recipes/1', { method: 'DELETE', apiKey: USER_KEY })
+    expect(res.status).toBe(401)
+    expect(vi.mocked(recipeService.deleteRecipe)).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when no API key provided', async () => {
+    const res = await request('/recipes/1', { method: 'DELETE', apiKey: null })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when recipe does not exist', async () => {
+    vi.mocked(recipeService.deleteRecipe).mockRejectedValue(
+      new NotFoundError('Recipe not found with id: 999'),
+    )
+    const res = await request('/recipes/999', { method: 'DELETE', apiKey: ADMIN_KEY })
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.message).toBe('Recipe not found with id: 999')
+  })
+})

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -1,0 +1,111 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { createDb } from '../db/client'
+import { buildSuccess } from '../lib/response'
+import {
+  createRecipe,
+  deleteRecipe,
+  getRecipe,
+  listRecipes,
+  updateRecipe,
+} from '../services/recipeService'
+
+export const recipeRouter = new Hono<{ Bindings: CloudflareBindings }>()
+
+const CuisineInputSchema = z.object({
+  id: z.number().int().positive().optional(),
+  name: z.string().optional(),
+})
+
+const IngredientInputSchema = z.object({
+  id: z.number().int().positive().optional(),
+  name: z.string().optional(),
+  unitId: z.number().int().positive(),
+  quantity: z.number().positive(),
+  notes: z.string().nullish(),
+})
+
+const TagInputSchema = z.object({
+  id: z.number().int().positive().optional(),
+  name: z.string().optional(),
+})
+
+const StepInputSchema = z.object({
+  stepNumber: z.number().int().positive(),
+  description: z.string().min(1),
+  tip: z.string().nullish(),
+})
+
+const RecipeSaveSchema = z.object({
+  name: z
+    .string()
+    .min(2, 'Recipe name must be between 2 to 150 characters.')
+    .max(150, 'Recipe name must be between 2 to 150 characters.'),
+  description: z.string().optional(),
+  calories: z.number().int().positive().nullable().optional(),
+  servings: z.number().int().positive('Servings must be a more than zero.'),
+  cookingTime: z.number().int().min(0, 'Cooking time cannot be negative.'),
+  preparationTime: z.number().int().positive('Preparation time cannot be zero minutes.'),
+  cuisine: CuisineInputSchema,
+  ingredients: z.array(IngredientInputSchema).min(1, 'There must be at least one ingredient.'),
+  steps: z.array(StepInputSchema).min(1, 'There must be at least one step.'),
+  tags: z.array(TagInputSchema).optional().default([]),
+  author: z.string().optional(),
+  imageUrl: z.string().nullable().optional(),
+})
+
+const RecipeUpdateSchema = z.object({
+  name: z.string().min(2).max(150).optional(),
+  description: z.string().optional(),
+  calories: z.number().int().positive().nullable().optional(),
+  servings: z.number().int().positive().optional(),
+  cookingTime: z.number().int().min(0).optional(),
+  preparationTime: z.number().int().positive().optional(),
+  cuisine: CuisineInputSchema.optional(),
+  author: z.string().optional(),
+  imageUrl: z.string().nullable().optional(),
+  ingredients: z.array(IngredientInputSchema).optional(),
+  tags: z.array(TagInputSchema).optional(),
+  steps: z.array(StepInputSchema).optional(),
+})
+
+recipeRouter.get('/', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const page = Number(c.req.query('page') ?? 0)
+  const limit = Number(c.req.query('limit') ?? 12)
+  const data = await listRecipes(db, page, limit)
+  return c.json(buildSuccess(200, 'Recipes retrieved', data), 200)
+})
+
+recipeRouter.post('/', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const body = await c.req.json()
+  const input = RecipeSaveSchema.parse(body)
+  const data = await createRecipe(db, input)
+  return c.json(buildSuccess(201, 'Recipe saved', data), 201, {
+    Location: `/recipes/${data.id}`,
+  })
+})
+
+recipeRouter.get('/:id', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const id = Number(c.req.param('id'))
+  const data = await getRecipe(db, id)
+  return c.json(buildSuccess(200, 'Recipe retrieved', data), 200)
+})
+
+recipeRouter.patch('/:id', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const id = Number(c.req.param('id'))
+  const body = await c.req.json()
+  const input = RecipeUpdateSchema.parse(body)
+  const data = await updateRecipe(db, id, input)
+  return c.json(buildSuccess(200, 'Recipe updated', data), 200)
+})
+
+recipeRouter.delete('/:id', async (c) => {
+  const db = createDb(c.env.DATABASE_URL)
+  const id = Number(c.req.param('id'))
+  await deleteRecipe(db, id)
+  return c.body(null, 204)
+})

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -1,0 +1,301 @@
+import { eq } from 'drizzle-orm'
+import { createDb } from '../db/client'
+import { recipes, recipeIngredients, recipeTags, recipeInstructionSteps } from '../db/schema'
+import { NotFoundError } from '../errors'
+import { resolveCuisine } from './cuisineService'
+import { resolveIngredient } from './ingredientService'
+import { resolveTag } from './tagService'
+import { resolveUnit } from './unitService'
+
+type Db = ReturnType<typeof createDb>
+
+export type CuisineInput = { id?: number; name?: string }
+export type IngredientInput = {
+  id?: number
+  name?: string
+  unitId: number
+  quantity: number
+  notes?: string | null
+}
+export type TagInput = { id?: number; name?: string }
+export type StepInput = { stepNumber: number; description: string; tip?: string | null }
+
+export type RecipeSaveInput = {
+  name: string
+  description?: string
+  calories?: number | null
+  servings: number
+  cookingTime: number
+  preparationTime: number
+  cuisine: CuisineInput
+  ingredients: IngredientInput[]
+  steps: StepInput[]
+  tags?: TagInput[]
+  author?: string
+  imageUrl?: string | null
+}
+
+export type RecipeUpdateInput = {
+  name?: string
+  description?: string
+  calories?: number | null
+  servings?: number
+  cookingTime?: number
+  preparationTime?: number
+  cuisine?: CuisineInput
+  author?: string
+  imageUrl?: string | null
+  ingredients?: IngredientInput[]
+  tags?: TagInput[]
+  steps?: StepInput[]
+}
+
+export type RecipeListItem = { id: number; name: string; imageUrl: string | null }
+
+export type RecipeIngredientResponse = {
+  id: number
+  name: string
+  unitId: number
+  unitName: string
+  abbreviation: string | null
+  quantity: number
+  notes: string | null
+}
+
+export type RecipeTagResponse = {
+  recipeTagId: number
+  id: number
+  name: string
+}
+
+export type RecipeStepResponse = {
+  stepId: number
+  stepNumber: number
+  description: string
+  tip: string | null
+  imageUrl: string | null
+}
+
+export type RecipeResponse = {
+  id: number
+  name: string
+  description: string
+  cuisine: { id: number; name: string }
+  author: string
+  calories: number | null
+  servings: number
+  cookingTime: number
+  preparationTime: number
+  imageUrl: string | null
+  createdAt: Date
+  updatedAt: Date
+  ingredients: RecipeIngredientResponse[]
+  tags: RecipeTagResponse[]
+  steps: RecipeStepResponse[]
+}
+
+async function resolveUniqueTags(db: Db, tagInputs: TagInput[]) {
+  const seen = new Set<string>()
+  const resolved = []
+  for (const t of tagInputs) {
+    const tag = await resolveTag(db, t.id, t.name)
+    const key = tag.name.toLowerCase().trim()
+    if (!seen.has(key)) {
+      seen.add(key)
+      resolved.push(tag)
+    }
+  }
+  return resolved
+}
+
+async function fetchFullRecipe(db: Db, id: number): Promise<RecipeResponse> {
+  const row = await db.query.recipes.findFirst({
+    where: eq(recipes.id, id),
+    with: {
+      cuisine: true,
+      ingredients: {
+        with: { ingredient: true, unit: true },
+      },
+      tags: {
+        with: { tag: true },
+      },
+      steps: {
+        orderBy: (steps, { asc }) => [asc(steps.stepNumber)],
+      },
+    },
+  })
+
+  if (!row) throw new NotFoundError(`Recipe not found with id: ${id}`)
+
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    cuisine: { id: row.cuisine.id, name: row.cuisine.name },
+    author: row.author,
+    calories: row.calories ?? null,
+    servings: row.servings,
+    cookingTime: row.cookingTime,
+    preparationTime: row.preparationTime,
+    imageUrl: row.imageUrl ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    ingredients: row.ingredients.map((ri) => ({
+      id: ri.ingredient.id,
+      name: ri.ingredient.name,
+      unitId: ri.unitId,
+      unitName: ri.unit.name,
+      abbreviation: ri.unit.abbreviation ?? null,
+      quantity: parseFloat(ri.quantity),
+      notes: ri.notes ?? null,
+    })),
+    tags: row.tags.map((rt) => ({
+      recipeTagId: rt.id,
+      id: rt.tag.id,
+      name: rt.tag.name,
+    })),
+    steps: row.steps.map((s) => ({
+      stepId: s.id,
+      stepNumber: s.stepNumber,
+      description: s.description,
+      tip: s.tip ?? null,
+      imageUrl: s.imageUrl ?? null,
+    })),
+  }
+}
+
+export async function listRecipes(db: Db, page: number, limit: number): Promise<RecipeListItem[]> {
+  const rows = await db
+    .select({ id: recipes.id, name: recipes.name, imageUrl: recipes.imageUrl })
+    .from(recipes)
+    .limit(limit)
+    .offset(page * limit)
+  return rows.map((r) => ({ id: r.id, name: r.name, imageUrl: r.imageUrl ?? null }))
+}
+
+export async function getRecipe(db: Db, id: number): Promise<RecipeResponse> {
+  return fetchFullRecipe(db, id)
+}
+
+export async function createRecipe(db: Db, input: RecipeSaveInput): Promise<RecipeResponse> {
+  const cuisine = await resolveCuisine(db, input.cuisine.id, input.cuisine.name)
+  const uniqueTags = await resolveUniqueTags(db, input.tags ?? [])
+
+  const now = new Date()
+  const [recipe] = await db
+    .insert(recipes)
+    .values({
+      name: input.name,
+      description: input.description ?? '',
+      cuisineId: cuisine.id,
+      author: input.author ?? '',
+      calories: input.calories,
+      servings: input.servings,
+      cookingTime: input.cookingTime,
+      preparationTime: input.preparationTime,
+      imageUrl: input.imageUrl,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+
+  for (const ing of input.ingredients) {
+    const ingredient = await resolveIngredient(db, ing.id, ing.name)
+    const unit = await resolveUnit(db, ing.unitId)
+    await db.insert(recipeIngredients).values({
+      recipeId: recipe.id,
+      ingredientId: ingredient.id,
+      unitId: unit.id,
+      quantity: String(ing.quantity),
+      notes: ing.notes,
+    })
+  }
+
+  for (const tag of uniqueTags) {
+    await db.insert(recipeTags).values({ recipeId: recipe.id, tagId: tag.id })
+  }
+
+  for (const step of input.steps) {
+    await db.insert(recipeInstructionSteps).values({
+      recipeId: recipe.id,
+      stepNumber: step.stepNumber,
+      description: step.description,
+      tip: step.tip,
+    })
+  }
+
+  return fetchFullRecipe(db, recipe.id)
+}
+
+export async function updateRecipe(
+  db: Db,
+  id: number,
+  input: RecipeUpdateInput,
+): Promise<RecipeResponse> {
+  const existing = await db.query.recipes.findFirst({ where: eq(recipes.id, id) })
+  if (!existing) throw new NotFoundError(`Recipe not found with id: ${id}`)
+
+  // updatedAt is always set explicitly on PATCH, as required by the spec.
+  // Note: unlike the Java source (which ignores null fields), null here nullifies
+  // nullable columns (calories, imageUrl). Non-nullable columns cannot be set to null.
+  const patch: Record<string, unknown> = { updatedAt: new Date() }
+
+  if (input.name !== undefined) patch.name = input.name
+  if (input.description !== undefined) patch.description = input.description
+  if (input.author !== undefined) patch.author = input.author
+  if (input.calories !== undefined) patch.calories = input.calories
+  if (input.servings !== undefined) patch.servings = input.servings
+  if (input.cookingTime !== undefined) patch.cookingTime = input.cookingTime
+  if (input.preparationTime !== undefined) patch.preparationTime = input.preparationTime
+  if (input.imageUrl !== undefined) patch.imageUrl = input.imageUrl
+
+  if (input.cuisine !== undefined) {
+    const cuisine = await resolveCuisine(db, input.cuisine.id, input.cuisine.name)
+    patch.cuisineId = cuisine.id
+  }
+
+  await db.update(recipes).set(patch).where(eq(recipes.id, id))
+
+  if (input.ingredients !== undefined) {
+    await db.delete(recipeIngredients).where(eq(recipeIngredients.recipeId, id))
+    for (const ing of input.ingredients) {
+      const ingredient = await resolveIngredient(db, ing.id, ing.name)
+      const unit = await resolveUnit(db, ing.unitId)
+      await db.insert(recipeIngredients).values({
+        recipeId: id,
+        ingredientId: ingredient.id,
+        unitId: unit.id,
+        quantity: String(ing.quantity),
+        notes: ing.notes,
+      })
+    }
+  }
+
+  if (input.tags !== undefined) {
+    await db.delete(recipeTags).where(eq(recipeTags.recipeId, id))
+    const uniqueTags = await resolveUniqueTags(db, input.tags)
+    for (const tag of uniqueTags) {
+      await db.insert(recipeTags).values({ recipeId: id, tagId: tag.id })
+    }
+  }
+
+  if (input.steps !== undefined) {
+    await db.delete(recipeInstructionSteps).where(eq(recipeInstructionSteps.recipeId, id))
+    for (const step of input.steps) {
+      await db.insert(recipeInstructionSteps).values({
+        recipeId: id,
+        stepNumber: step.stepNumber,
+        description: step.description,
+        tip: step.tip,
+      })
+    }
+  }
+
+  return fetchFullRecipe(db, id)
+}
+
+export async function deleteRecipe(db: Db, id: number): Promise<void> {
+  const existing = await db.query.recipes.findFirst({ where: eq(recipes.id, id) })
+  if (!existing) throw new NotFoundError(`Recipe not found with id: ${id}`)
+  await db.delete(recipes).where(eq(recipes.id, id))
+}


### PR DESCRIPTION
Closes #13

## Summary
- `GET /recipes?page&limit` — paginated slim list (`id`, `name`, `imageUrl`)
- `POST /recipes` — creates recipe with resolve-or-create for cuisine/tags/ingredients, strict unit resolution by ID; returns 201 + `Location` header
- `GET /recipes/:id` — full response with all relations (cuisine, ingredients+unit, tags, steps)
- `PATCH /recipes/:id` — partial update; absent fields untouched, null nullifies nullable columns; child collections replaced when present
- `DELETE /recipes/:id` — 204; requires admin key; 404 if missing

## Test plan
- [ ] `pnpm test` passes (68 tests, all green)
- [ ] `pnpm lint` passes
- [ ] `GET /recipes` returns 200 with slim list items
- [ ] `POST /recipes` returns 201 with `Location: /recipes/:id` and full nested response
- [ ] Validation errors (short name, zero servings, negative cookingTime, empty ingredients/steps) return 400 with matching message
- [ ] Missing unit ID returns 404
- [ ] `GET /recipes/:id` returns full response; unknown ID returns 404
- [ ] `PATCH /recipes/:id` with `{ calories: null }` nullifies the column; absent collections untouched
- [ ] `DELETE /recipes/:id` with user key returns 401; with admin key returns 204; unknown ID returns 404
- [ ] Manually verify against running dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)