### PR TITLE
feat: add image upload and deletion endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { cuisineRouter } from './routes/cuisines'
 import { ingredientRouter } from './routes/ingredients'
 import { tagRouter } from './routes/tags'
 import { unitRouter } from './routes/units'
+import { imageRouter } from './routes/images'
 import { recipeRouter } from './routes/recipes'
 
 const app = new Hono<{ Bindings: CloudflareBindings }>()
@@ -21,6 +22,7 @@ app.route('/cuisines', cuisineRouter)
 app.route('/ingredients', ingredientRouter)
 app.route('/tags', tagRouter)
 app.route('/units', unitRouter)
+app.route('/recipes/images', imageRouter)
 app.route('/recipes', recipeRouter)
 
 export default app

--- a/src/routes/images.test.ts
+++ b/src/routes/images.test.ts
@@ -95,13 +95,16 @@ describe('POST /recipes/images', () => {
     expect(vi.mocked(imageService.uploadImage)).not.toHaveBeenCalled()
   })
 
-  it('returns 400 when file exceeds 25MB', async () => {
-    const res = await uploadRequest(makeFormData(makeFile('', 'big.jpg', 'image/jpeg', 25 * 1024 * 1024 + 1)), USER_KEY)
+  it('returns 400 when service rejects file exceeding 25MB', async () => {
+    vi.mocked(imageService.uploadImage).mockRejectedValue(
+      new BadRequestError('File exceeds 25MB limit'),
+    )
+
+    const res = await uploadRequest(makeFormData(makeFile()), USER_KEY)
     const body = await res.json()
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('File exceeds 25MB limit')
-    expect(vi.mocked(imageService.uploadImage)).not.toHaveBeenCalled()
   })
 
   it('propagates BadRequestError from service as 400 (error handler integration)', async () => {

--- a/src/routes/images.test.ts
+++ b/src/routes/images.test.ts
@@ -1,0 +1,181 @@
+import { Hono } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../errors'
+import { authMiddleware } from '../middleware/auth'
+import { errorHandler } from '../middleware/error-handler'
+import * as imageService from '../services/image-service'
+import { imageRouter } from './images'
+
+vi.mock('../services/image-service')
+
+type TestBindings = {
+  USER_API_KEY: string
+  ADMIN_API_KEY: string
+  IMAGE_BUCKET: R2Bucket
+  R2_PUBLIC_URL: string
+}
+
+const USER_KEY = 'test-user-key'
+const ADMIN_KEY = 'test-admin-key'
+const TEST_ENV: TestBindings = {
+  USER_API_KEY: USER_KEY,
+  ADMIN_API_KEY: ADMIN_KEY,
+  IMAGE_BUCKET: {} as unknown as R2Bucket,
+  R2_PUBLIC_URL: 'https://pub-test.r2.dev',
+}
+
+const UPLOADED_URL = 'https://pub-test.r2.dev/recipes/abc-123.jpg'
+
+function buildTestApp() {
+  const app = new Hono<{ Bindings: TestBindings }>()
+  app.onError(errorHandler)
+  app.use('*', authMiddleware)
+  app.route('/recipes/images', imageRouter)
+  return app
+}
+
+const app = buildTestApp()
+
+function uploadRequest(formData: FormData, apiKey?: string | null) {
+  const headers: Record<string, string> = {}
+  if (apiKey != null) headers['X-Api-Key'] = apiKey
+  return app.request('/recipes/images', { method: 'POST', body: formData, headers }, TEST_ENV)
+}
+
+function deleteRequest(key: string, apiKey?: string | null) {
+  const headers: Record<string, string> = {}
+  if (apiKey != null) headers['X-Api-Key'] = apiKey
+  return app.request(
+    `/recipes/images?key=${encodeURIComponent(key)}`,
+    { method: 'DELETE', headers },
+    TEST_ENV,
+  )
+}
+
+function makeFormData(file: File | null) {
+  const form = new FormData()
+  if (file) form.append('file', file)
+  return form
+}
+
+function makeFile(
+  content = 'fake image',
+  name = 'photo.jpg',
+  type = 'image/jpeg',
+  size?: number,
+) {
+  if (size !== undefined) {
+    return new File([new Uint8Array(size)], name, { type })
+  }
+  return new File([content], name, { type })
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /recipes/images', () => {
+  it('returns 200 with public URL on valid upload', async () => {
+    vi.mocked(imageService.uploadImage).mockResolvedValue(UPLOADED_URL)
+
+    const res = await uploadRequest(makeFormData(makeFile()), USER_KEY)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.message).toBe('Image uploaded')
+    expect(body.data).toBe(UPLOADED_URL)
+  })
+
+  it('returns 400 when file field is missing from form', async () => {
+    const res = await uploadRequest(makeFormData(null), USER_KEY)
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.message).toBe('File must not be empty')
+    expect(vi.mocked(imageService.uploadImage)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when file exceeds 25MB', async () => {
+    const res = await uploadRequest(makeFormData(makeFile('', 'big.jpg', 'image/jpeg', 25 * 1024 * 1024 + 1)), USER_KEY)
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.message).toBe('File exceeds 25MB limit')
+    expect(vi.mocked(imageService.uploadImage)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when service rejects empty file', async () => {
+    vi.mocked(imageService.uploadImage).mockRejectedValue(
+      new BadRequestError('File must not be empty'),
+    )
+
+    const res = await uploadRequest(makeFormData(makeFile('')), USER_KEY)
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.message).toBe('File must not be empty')
+  })
+
+  it('returns 400 when service rejects unsupported file type', async () => {
+    vi.mocked(imageService.uploadImage).mockRejectedValue(
+      new BadRequestError('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif'),
+    )
+
+    const res = await uploadRequest(makeFormData(makeFile('pdf', 'doc.pdf', 'application/pdf')), USER_KEY)
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.message).toBe('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif')
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await uploadRequest(makeFormData(makeFile()), null)
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('DELETE /recipes/images', () => {
+  it('returns 204 on valid key', async () => {
+    vi.mocked(imageService.deleteImage).mockResolvedValue(undefined)
+
+    const res = await deleteRequest('recipes/abc-123.jpg', USER_KEY)
+    expect(res.status).toBe(204)
+    expect(vi.mocked(imageService.deleteImage)).toHaveBeenCalledOnce()
+  })
+
+  it('returns 400 when key is blank', async () => {
+    vi.mocked(imageService.deleteImage).mockRejectedValue(
+      new BadRequestError('Image key must not be empty'),
+    )
+
+    const res = await deleteRequest('', USER_KEY)
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.message).toBe('Image key must not be empty')
+  })
+
+  it('returns 400 when key does not start with recipes/', async () => {
+    vi.mocked(imageService.deleteImage).mockRejectedValue(
+      new BadRequestError('Invalid image key'),
+    )
+
+    const res = await deleteRequest('other/abc-123.jpg', USER_KEY)
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.message).toBe('Invalid image key')
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await deleteRequest('recipes/abc-123.jpg', null)
+    expect(res.status).toBe(401)
+  })
+
+  it('allows delete with user key (not admin-only)', async () => {
+    vi.mocked(imageService.deleteImage).mockResolvedValue(undefined)
+
+    const res = await deleteRequest('recipes/abc-123.jpg', USER_KEY)
+    expect(res.status).toBe(204)
+  })
+})

--- a/src/routes/images.test.ts
+++ b/src/routes/images.test.ts
@@ -104,7 +104,7 @@ describe('POST /recipes/images', () => {
     expect(vi.mocked(imageService.uploadImage)).not.toHaveBeenCalled()
   })
 
-  it('returns 400 when service rejects empty file', async () => {
+  it('propagates BadRequestError from service as 400 (error handler integration)', async () => {
     vi.mocked(imageService.uploadImage).mockRejectedValue(
       new BadRequestError('File must not be empty'),
     )

--- a/src/routes/images.ts
+++ b/src/routes/images.ts
@@ -1,0 +1,29 @@
+import { Hono } from 'hono'
+import { buildError, buildSuccess } from '../lib/response'
+import { deleteImage, uploadImage } from '../services/image-service'
+
+const MAX_FILE_SIZE = 25 * 1024 * 1024 // 25 MB
+
+export const imageRouter = new Hono<{ Bindings: CloudflareBindings }>()
+
+imageRouter.post('/', async (c) => {
+  const formData = await c.req.formData()
+  const file = formData.get('file')
+
+  if (!(file instanceof File)) {
+    return c.json(buildError(400, 'File must not be empty', c.req.path), 400)
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return c.json(buildError(400, 'File exceeds 25MB limit', c.req.path), 400)
+  }
+
+  const url = await uploadImage(c.env.IMAGE_BUCKET, c.env.R2_PUBLIC_URL, file)
+  return c.json(buildSuccess(200, 'Image uploaded', url), 200)
+})
+
+imageRouter.delete('/', async (c) => {
+  const key = c.req.query('key') ?? ''
+  await deleteImage(c.env.IMAGE_BUCKET, key)
+  return c.body(null, 204)
+})

--- a/src/routes/images.ts
+++ b/src/routes/images.ts
@@ -2,8 +2,6 @@ import { Hono } from 'hono'
 import { buildError, buildSuccess } from '../lib/response'
 import { deleteImage, uploadImage } from '../services/image-service'
 
-const MAX_FILE_SIZE = 25 * 1024 * 1024 // 25 MB
-
 export const imageRouter = new Hono<{ Bindings: CloudflareBindings }>()
 
 imageRouter.post('/', async (c) => {
@@ -12,10 +10,6 @@ imageRouter.post('/', async (c) => {
 
   if (!(file instanceof File)) {
     return c.json(buildError(400, 'File must not be empty', c.req.path), 400)
-  }
-
-  if (file.size > MAX_FILE_SIZE) {
-    return c.json(buildError(400, 'File exceeds 25MB limit', c.req.path), 400)
   }
 
   const url = await uploadImage(c.env.IMAGE_BUCKET, c.env.R2_PUBLIC_URL, file)

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { authMiddleware } from '../middleware/auth'
-import { errorHandler } from '../middleware/errorHandler'
+import { errorHandler } from '../middleware/error-handler'
 import { NotFoundError } from '../errors'
 import * as recipeService from '../services/recipeService'
 import { recipeRouter } from './recipes'

--- a/src/services/image-service.test.ts
+++ b/src/services/image-service.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../errors'
+import { deleteImage, uploadImage } from './image-service'
+
+const PUBLIC_URL = 'https://pub-test.r2.dev'
+
+function makeBucket() {
+  return {
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue(undefined),
+  } as unknown as R2Bucket
+}
+
+function makeFile(content: string | Uint8Array, name: string, type: string) {
+  return new File([content], name, { type })
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('uploadImage', () => {
+  it('throws BadRequestError for a zero-byte file', async () => {
+    const bucket = makeBucket()
+    const file = makeFile(new Uint8Array(0), 'empty.jpg', 'image/jpeg')
+
+    await expect(uploadImage(bucket, PUBLIC_URL, file)).rejects.toThrow(
+      new BadRequestError('File must not be empty'),
+    )
+    expect(vi.mocked(bucket.put)).not.toHaveBeenCalled()
+  })
+
+  it('throws BadRequestError for an unsupported MIME type', async () => {
+    const bucket = makeBucket()
+    const file = makeFile('data', 'doc.pdf', 'application/pdf')
+
+    await expect(uploadImage(bucket, PUBLIC_URL, file)).rejects.toThrow(
+      new BadRequestError('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif'),
+    )
+    expect(vi.mocked(bucket.put)).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['image/jpeg', 'jpg'],
+    ['image/png', 'png'],
+    ['image/webp', 'webp'],
+    ['image/gif', 'gif'],
+    ['image/heic', 'heic'],
+    ['image/heif', 'heif'],
+  ])('uploads %s and returns URL with .%s extension', async (mimeType, ext) => {
+    const bucket = makeBucket()
+    const file = makeFile('data', `photo.${ext}`, mimeType)
+
+    const url = await uploadImage(bucket, PUBLIC_URL, file)
+
+    expect(vi.mocked(bucket.put)).toHaveBeenCalledOnce()
+    const [key, , opts] = vi.mocked(bucket.put).mock.calls[0]
+    expect(key).toMatch(new RegExp(`^recipes/[\\w-]+\\.${ext}$`))
+    expect(opts).toEqual({ httpMetadata: { contentType: mimeType } })
+    expect(url).toBe(`${PUBLIC_URL}/${key}`)
+  })
+
+  it('strips trailing slash from publicUrl before building the URL', async () => {
+    const bucket = makeBucket()
+    const file = makeFile('data', 'photo.jpg', 'image/jpeg')
+
+    const url = await uploadImage(bucket, 'https://pub-test.r2.dev/', file)
+
+    expect(url).toMatch(/^https:\/\/pub-test\.r2\.dev\/recipes\/[^/]/)
+    expect(url).not.toMatch(/\.dev\/\//)
+  })
+})
+
+describe('deleteImage', () => {
+  it('throws BadRequestError for a blank key', async () => {
+    const bucket = makeBucket()
+
+    await expect(deleteImage(bucket, '')).rejects.toThrow(
+      new BadRequestError('Image key must not be empty'),
+    )
+    expect(vi.mocked(bucket.delete)).not.toHaveBeenCalled()
+  })
+
+  it('throws BadRequestError for a whitespace-only key', async () => {
+    const bucket = makeBucket()
+
+    await expect(deleteImage(bucket, '   ')).rejects.toThrow(
+      new BadRequestError('Image key must not be empty'),
+    )
+    expect(vi.mocked(bucket.delete)).not.toHaveBeenCalled()
+  })
+
+  it('throws BadRequestError when key does not start with recipes/', async () => {
+    const bucket = makeBucket()
+
+    await expect(deleteImage(bucket, 'uploads/photo.jpg')).rejects.toThrow(
+      new BadRequestError('Invalid image key'),
+    )
+    expect(vi.mocked(bucket.delete)).not.toHaveBeenCalled()
+  })
+
+  it('calls bucket.delete with the key on a valid prefixed key', async () => {
+    const bucket = makeBucket()
+
+    await deleteImage(bucket, 'recipes/abc-123.jpg')
+
+    expect(vi.mocked(bucket.delete)).toHaveBeenCalledWith('recipes/abc-123.jpg')
+  })
+})

--- a/src/services/image-service.test.ts
+++ b/src/services/image-service.test.ts
@@ -30,6 +30,17 @@ describe('uploadImage', () => {
     expect(vi.mocked(bucket.put)).not.toHaveBeenCalled()
   })
 
+  it('throws BadRequestError for a file exceeding 25MB', async () => {
+    const bucket = makeBucket()
+    // Use a mock object so we don't allocate 25MB in the test
+    const file = { size: 25 * 1024 * 1024 + 1, type: 'image/jpeg' } as unknown as File
+
+    await expect(uploadImage(bucket, PUBLIC_URL, file)).rejects.toThrow(
+      new BadRequestError('File exceeds 25MB limit'),
+    )
+    expect(vi.mocked(bucket.put)).not.toHaveBeenCalled()
+  })
+
   it('throws BadRequestError for an unsupported MIME type', async () => {
     const bucket = makeBucket()
     const file = makeFile('data', 'doc.pdf', 'application/pdf')

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -1,0 +1,52 @@
+import { BadRequestError } from '../errors'
+
+const ALLOWED_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+])
+
+const EXTENSION_MAP: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/heic': 'heic',
+  'image/heif': 'heif',
+}
+
+export async function uploadImage(
+  bucket: R2Bucket,
+  publicUrl: string,
+  file: File,
+): Promise<string> {
+  if (file.size === 0) {
+    throw new BadRequestError('File must not be empty')
+  }
+
+  const contentType = file.type
+  if (!ALLOWED_TYPES.has(contentType)) {
+    throw new BadRequestError('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif')
+  }
+
+  const ext = EXTENSION_MAP[contentType] ?? 'jpg'
+  const key = `recipes/${crypto.randomUUID()}.${ext}`
+
+  await bucket.put(key, await file.arrayBuffer(), { httpMetadata: { contentType } })
+
+  return `${publicUrl.replace(/\/$/, '')}/${key}`
+}
+
+export async function deleteImage(bucket: R2Bucket, key: string): Promise<void> {
+  if (!key || key.trim().length === 0) {
+    throw new BadRequestError('Image key must not be empty')
+  }
+  if (!key.startsWith('recipes/')) {
+    throw new BadRequestError('Invalid image key')
+  }
+
+  await bucket.delete(key)
+}

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -1,5 +1,7 @@
 import { BadRequestError } from '../errors'
 
+const MAX_FILE_SIZE = 25 * 1024 * 1024 // 25 MB
+
 const ALLOWED_TYPES = new Set([
   'image/jpeg',
   'image/png',
@@ -25,6 +27,10 @@ export async function uploadImage(
 ): Promise<string> {
   if (file.size === 0) {
     throw new BadRequestError('File must not be empty')
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    throw new BadRequestError('File exceeds 25MB limit')
   }
 
   const contentType = file.type

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -10,10 +10,10 @@ import {
   tags,
 } from '../db/schema'
 import { NotFoundError } from '../errors'
-import { resolveCuisine } from './cuisineService'
-import { resolveIngredient } from './ingredientService'
-import { resolveTag } from './tagService'
-import { resolveUnit } from './unitService'
+import { resolveCuisine } from './cuisine-service'
+import { resolveIngredient } from './ingredient-service'
+import { resolveTag } from './tag-service'
+import { resolveUnit } from './unit-service'
 
 type Db = ReturnType<typeof createDb>
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1,5 +1,16 @@
+interface R2Bucket {
+  put(
+    key: string,
+    value: ArrayBuffer | ArrayBufferView | string | Blob | ReadableStream,
+    options?: { httpMetadata?: { contentType?: string } },
+  ): Promise<unknown>
+  delete(keys: string | string[]): Promise<void>
+}
+
 interface CloudflareBindings {
   DATABASE_URL: string
   USER_API_KEY: string
   ADMIN_API_KEY: string
+  IMAGE_BUCKET: R2Bucket
+  R2_PUBLIC_URL: string
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,9 +5,7 @@
   "compatibility_date": "2026-07-29",
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
-    // Public base URL for the R2 bucket (e.g. https://pub-<hash>.r2.dev).
-    // Override per environment in the Cloudflare dashboard if needed.
-    "R2_PUBLIC_URL": "https://your-public-bucket-url.r2.dev"
+    "R2_PUBLIC_URL": "https://pub-017886dc539b41789e7c76de04239c5d.r2.dev"
   },
   // "kv_namespaces": [
   //   {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,21 +4,23 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-29",
   "compatibility_flags": ["nodejs_compat"],
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
+  "vars": {
+    // Public base URL for the R2 bucket (e.g. https://pub-<hash>.r2.dev).
+    // Override per environment in the Cloudflare dashboard if needed.
+    "R2_PUBLIC_URL": "https://your-public-bucket-url.r2.dev"
+  },
   // "kv_namespaces": [
   //   {
   //     "binding": "MY_KV_NAMESPACE",
   //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   //   }
   // ],
-  // "r2_buckets": [
-  //   {
-  //     "binding": "MY_BUCKET",
-  //     "bucket_name": "my-bucket"
-  //   }
-  // ],
+  "r2_buckets": [
+    {
+      "binding": "IMAGE_BUCKET",
+      "bucket_name": "recipe-images"
+    }
+  ],
   // "d1_databases": [
   //   {
   //     "binding": "MY_DB",


### PR DESCRIPTION
Closes #15

## Summary
- `POST /recipes/images` — accepts `multipart/form-data` with a `file` field, validates type and size, uploads to Cloudflare R2, returns public URL in the standard success envelope
- `DELETE /recipes/images?key=<key>` — validates key is non-blank and prefixed with `recipes/`, deletes from R2, returns 204
- Uses **native R2 bindings** (`env.IMAGE_BUCKET`) — no AWS SDK needed, avoids Workers runtime incompatibility
- `IMAGE_BUCKET` R2 binding and `R2_PUBLIC_URL` var added to `wrangler.jsonc`; `R2Bucket` ambient interface added to `worker-configuration.d.ts`
- Image router mounted at `/recipes/images` **before** the recipe router so the `:id` wildcard doesn't shadow it
- Also fixes stale camelCase import paths in `recipeService.ts` and `recipes.test.ts` introduced when the kebab-case rename (#34) and recipe CRUD (#13) branches diverged

## Validation rules
| Case | Status | Message |
|---|---|---|
| No `file` field in form | 400 | `File must not be empty` |
| File > 25 MB | 400 | `File exceeds 25MB limit` |
| File size is 0 | 400 | `File must not be empty` |
| Unsupported MIME type | 400 | `Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif` |
| Blank delete key | 400 | `Image key must not be empty` |
| Key missing `recipes/` prefix | 400 | `Invalid image key` |
| No API key | 401 | — |

## Test plan
- [x] `pnpm test` — 92 tests pass (9 suites)
- [x] `pnpm lint` — no errors
- [x] Manual verify: configure R2 bucket + `R2_PUBLIC_URL` in wrangler, run `pnpm dev`, upload and delete an image

## Before deploying
Update `wrangler.jsonc` (or the Cloudflare dashboard) with your actual R2 bucket name and set `R2_PUBLIC_URL` to the bucket's public URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)