### PR TITLE
refactor: move business logic from routers into service layer

### DIFF
--- a/src/routes/images.ts
+++ b/src/routes/images.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
-import { buildError, buildSuccess } from '../lib/response'
+import { BadRequestError } from '../errors'
+import { buildSuccess } from '../lib/response'
 import { deleteImage, uploadImage } from '../services/image-service'
 
 export const imageRouter = new Hono<{ Bindings: CloudflareBindings }>()
@@ -9,7 +10,7 @@ imageRouter.post('/', async (c) => {
   const file = formData.get('file')
 
   if (!(file instanceof File)) {
-    return c.json(buildError(400, 'File must not be empty', c.req.path), 400)
+    throw new BadRequestError('File must not be empty')
   }
 
   const url = await uploadImage(c.env.IMAGE_BUCKET, c.env.R2_PUBLIC_URL, file)

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -120,10 +120,10 @@ describe('GET /recipes', () => {
     expect(vi.mocked(recipeService.listRecipes)).toHaveBeenCalledWith(expect.anything(), 2, 5)
   })
 
-  it('caps limit at 100', async () => {
+  it('passes limit to service uncapped', async () => {
     const res = await request('/recipes?limit=999')
     expect(res.status).toBe(200)
-    expect(vi.mocked(recipeService.listRecipes)).toHaveBeenCalledWith(expect.anything(), 0, 100)
+    expect(vi.mocked(recipeService.listRecipes)).toHaveBeenCalledWith(expect.anything(), 0, 999)
   })
 
   it('returns 400 for non-numeric page or limit', async () => {

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { createDb } from '../db/client'
-import { buildError, buildSuccess } from '../lib/response'
+import { buildSuccess } from '../lib/response'
+import { BadRequestError } from '../errors'
 import {
   createRecipe,
   deleteRecipe,
@@ -100,13 +101,13 @@ recipeRouter.get('/', async (c) => {
   const ingredientIdRaw = c.req.query('ingredientId')
 
   if (tagIdRaw !== undefined && isNaN(Number(tagIdRaw))) {
-    return c.json(buildError(400, 'Invalid tagId', c.req.path), 400)
+    throw new BadRequestError('Invalid tagId')
   }
   if (cuisineIdRaw !== undefined && isNaN(Number(cuisineIdRaw))) {
-    return c.json(buildError(400, 'Invalid cuisineId', c.req.path), 400)
+    throw new BadRequestError('Invalid cuisineId')
   }
   if (ingredientIdRaw !== undefined && isNaN(Number(ingredientIdRaw))) {
-    return c.json(buildError(400, 'Invalid ingredientId', c.req.path), 400)
+    throw new BadRequestError('Invalid ingredientId')
   }
 
   const tagId = tagIdRaw !== undefined ? Number(tagIdRaw) : undefined
@@ -132,9 +133,9 @@ recipeRouter.get('/', async (c) => {
   const page = Number(c.req.query('page') ?? 0)
   const limit = Number(c.req.query('limit') ?? 12)
   if (isNaN(page) || isNaN(limit)) {
-    return c.json(buildError(400, 'Invalid page or limit', c.req.path), 400)
+    throw new BadRequestError('Invalid page or limit')
   }
-  const data = await listRecipes(db, page, Math.min(limit, 100))
+  const data = await listRecipes(db, page, limit)
   return c.json(buildSuccess(200, 'Recipes retrieved', data), 200)
 })
 
@@ -150,7 +151,7 @@ recipeRouter.post('/', async (c) => {
 
 recipeRouter.get('/:id', async (c) => {
   const id = Number(c.req.param('id'))
-  if (isNaN(id)) return c.json(buildError(400, 'Invalid recipe id', c.req.path), 400)
+  if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
   const db = createDb(c.env.DATABASE_URL)
   const data = await getRecipe(db, id)
   return c.json(buildSuccess(200, 'Recipe retrieved', data), 200)
@@ -158,7 +159,7 @@ recipeRouter.get('/:id', async (c) => {
 
 recipeRouter.patch('/:id', async (c) => {
   const id = Number(c.req.param('id'))
-  if (isNaN(id)) return c.json(buildError(400, 'Invalid recipe id', c.req.path), 400)
+  if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
   const db = createDb(c.env.DATABASE_URL)
   const body = await c.req.json()
   const input = RecipeUpdateSchema.parse(body)
@@ -168,7 +169,7 @@ recipeRouter.patch('/:id', async (c) => {
 
 recipeRouter.delete('/:id', async (c) => {
   const id = Number(c.req.param('id'))
-  if (isNaN(id)) return c.json(buildError(400, 'Invalid recipe id', c.req.path), 400)
+  if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
   const db = createDb(c.env.DATABASE_URL)
   await deleteRecipe(db, id)
   return c.body(null, 204)

--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { listRecipes } from './recipeService'
+
+function makeDb(rows: { id: number; name: string; imageUrl: string | null }[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockResolvedValue(rows),
+  }
+  return {
+    db: { select: vi.fn().mockReturnValue(chain) } as unknown as Parameters<typeof listRecipes>[0],
+    chain,
+  }
+}
+
+describe('listRecipes', () => {
+  it('caps limit at 100', async () => {
+    const { db, chain } = makeDb([])
+    await listRecipes(db, 0, 999)
+    expect(chain.limit).toHaveBeenCalledWith(100)
+    expect(chain.offset).toHaveBeenCalledWith(0)
+  })
+
+  it('passes limit through when under 100', async () => {
+    const { db, chain } = makeDb([])
+    await listRecipes(db, 0, 12)
+    expect(chain.limit).toHaveBeenCalledWith(12)
+  })
+
+  it('applies cap to offset calculation', async () => {
+    const { db, chain } = makeDb([])
+    await listRecipes(db, 2, 999)
+    expect(chain.limit).toHaveBeenCalledWith(100)
+    expect(chain.offset).toHaveBeenCalledWith(200)
+  })
+})

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -185,12 +185,13 @@ async function fetchFullRecipe(db: Db, id: number): Promise<RecipeResponse> {
 }
 
 export async function listRecipes(db: Db, page: number, limit: number): Promise<RecipeListItem[]> {
+  const safeLimit = Math.min(limit, 100)
   const rows = await db
     .select({ id: recipes.id, name: recipes.name, imageUrl: recipes.imageUrl })
     .from(recipes)
     .orderBy(asc(recipes.id))
-    .limit(limit)
-    .offset(page * limit)
+    .limit(safeLimit)
+    .offset(page * safeLimit)
   return rows.map((r) => ({ id: r.id, name: r.name, imageUrl: r.imageUrl ?? null }))
 }
 


### PR DESCRIPTION
## Summary

- Replace all inline `buildError(400, ...)` returns in routers with `throw new BadRequestError()` so validation errors flow through the error handler middleware consistently
- Move the `Math.min(limit, 100)` page-size cap from the recipe router into `listRecipes` in the service, where business rules belong
- Add `recipeService.test.ts` with unit tests covering the cap and its effect on offset calculation

## Test plan

- [ ] `pnpm test` passes (109 tests, all green)
- [ ] `pnpm run lint` passes with no warnings
- [ ] Invalid query params (`?tagId=abc`, `?page=abc`) still return 400
- [ ] `?limit=999` is capped to 100 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)