### PR TITLE
test: add recipe search unit tests and fix project-wide test type errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,4 +10,10 @@ export default [
   // Type-aware rules (no-floating-promises, etc.) require parserOptions.project — deferred until tsconfig paths are stable.
   ...tsPlugin.configs['flat/recommended'],
   prettierConfig,
+  {
+    files: ['**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
 ]

--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -44,7 +44,7 @@ describe('authMiddleware', () => {
 
     it('returns the standard error envelope', async () => {
       const res = await request('GET', '/recipes')
-      const body = await res.json()
+      const body = await res.json() as Record<string, any>
       expect(body.status).toBe(401)
       expect(body.message).toBe('Invalid or missing API key')
       expect(body.path).toBe('/recipes')
@@ -104,7 +104,7 @@ describe('authMiddleware', () => {
 
     it('returns the standard error envelope when rejecting user key', async () => {
       const res = await request('DELETE', '/recipes/123', USER_KEY)
-      const body = await res.json()
+      const body = await res.json() as Record<string, any>
       expect(body.status).toBe(401)
       expect(body.message).toBe('Invalid or missing API key')
       expect(body.path).toBe('/recipes/123')

--- a/src/middleware/error-handler.test.ts
+++ b/src/middleware/error-handler.test.ts
@@ -44,7 +44,7 @@ const ISO_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 describe('errorHandler', () => {
   it('maps NotFoundError to 404 with default message', async () => {
     const res = await app.request('/throw/not-found')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(404)
     expect(body.message).toBe('Not found')
@@ -53,7 +53,7 @@ describe('errorHandler', () => {
 
   it('maps NotFoundError to 404 with custom message', async () => {
     const res = await app.request('/throw/not-found-custom')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(404)
     expect(body.message).toBe('Tag not found')
@@ -61,7 +61,7 @@ describe('errorHandler', () => {
 
   it('maps BadRequestError to 400 with default message', async () => {
     const res = await app.request('/throw/bad-request')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('Bad request')
@@ -69,7 +69,7 @@ describe('errorHandler', () => {
 
   it('maps BadRequestError to 400 with custom message', async () => {
     const res = await app.request('/throw/bad-request-custom')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('Name is required')
@@ -77,7 +77,7 @@ describe('errorHandler', () => {
 
   it('maps DuplicateError to 409 with default message', async () => {
     const res = await app.request('/throw/duplicate')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(409)
     expect(body.message).toBe('Data integrity violation')
@@ -85,7 +85,7 @@ describe('errorHandler', () => {
 
   it('maps DuplicateError to 409 with custom message', async () => {
     const res = await app.request('/throw/duplicate-custom')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(409)
     expect(body.message).toBe('Cuisine already exists')
@@ -93,7 +93,7 @@ describe('errorHandler', () => {
 
   it('maps ZodError to 400 with first issue message only', async () => {
     const res = await app.request('/throw/zod')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     // z.object({ name: z.string() }).parse({ name: 42 }) produces a single issue
     // for the `name` field; only that first issue's message is surfaced
@@ -112,7 +112,7 @@ describe('errorHandler', () => {
 
   it('includes correct envelope shape on error responses', async () => {
     const res = await app.request('/throw/not-found')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(ISO_REGEX.test(body.timestamp)).toBe(true)
     expect(typeof body.status).toBe('number')

--- a/src/middleware/rate-limiter.test.ts
+++ b/src/middleware/rate-limiter.test.ts
@@ -52,7 +52,7 @@ describe('rateLimiterMiddleware', () => {
       await request(app, USER_KEY)
     }
     const res = await request(app, USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.status).toBe(429)
     expect(body.message).toBe('Rate limit exceeded')
     expect(body.path).toBe('/recipes')

--- a/src/routes/cuisines.test.ts
+++ b/src/routes/cuisines.test.ts
@@ -54,7 +54,7 @@ describe('GET /cuisines', () => {
   it('returns 200 with all cuisines when no query param', async () => {
     const res = await request('/cuisines', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Cuisines retrieved')
     expect(body.data).toEqual(SAMPLE_CUISINES)
@@ -64,7 +64,7 @@ describe('GET /cuisines', () => {
   it('returns all cuisines for empty query string', async () => {
     const res = await request('/cuisines?query=', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Cuisines retrieved')
     expect(vi.mocked(cuisineService.listCuisines)).toHaveBeenCalledOnce()
     expect(vi.mocked(cuisineService.searchCuisines)).not.toHaveBeenCalled()
@@ -73,7 +73,7 @@ describe('GET /cuisines', () => {
   it('returns all cuisines for whitespace-only query', async () => {
     const res = await request('/cuisines?query=   ', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Cuisines retrieved')
     expect(vi.mocked(cuisineService.listCuisines)).toHaveBeenCalledOnce()
     expect(vi.mocked(cuisineService.searchCuisines)).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('GET /cuisines', () => {
     vi.mocked(cuisineService.searchCuisines).mockResolvedValue([{ id: 1, name: 'Italian' }])
     const res = await request('/cuisines?query=ital', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Cuisines queried')
     expect(body.data).toEqual([{ id: 1, name: 'Italian' }])
     expect(vi.mocked(cuisineService.searchCuisines)).toHaveBeenCalledWith(expect.anything(), 'ital')
@@ -94,7 +94,7 @@ describe('GET /cuisines', () => {
     vi.mocked(cuisineService.searchCuisines).mockResolvedValue([])
     const res = await request('/cuisines?query=zzz', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Cuisines queried')
     expect(body.data).toEqual([])
   })

--- a/src/routes/images.test.ts
+++ b/src/routes/images.test.ts
@@ -79,7 +79,7 @@ describe('POST /recipes/images', () => {
     vi.mocked(imageService.uploadImage).mockResolvedValue(UPLOADED_URL)
 
     const res = await uploadRequest(makeFormData(makeFile()), USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(200)
     expect(body.message).toBe('Image uploaded')
@@ -88,7 +88,7 @@ describe('POST /recipes/images', () => {
 
   it('returns 400 when file field is missing from form', async () => {
     const res = await uploadRequest(makeFormData(null), USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('File must not be empty')
@@ -101,7 +101,7 @@ describe('POST /recipes/images', () => {
     )
 
     const res = await uploadRequest(makeFormData(makeFile()), USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('File exceeds 25MB limit')
@@ -113,7 +113,7 @@ describe('POST /recipes/images', () => {
     )
 
     const res = await uploadRequest(makeFormData(makeFile('')), USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('File must not be empty')
@@ -125,7 +125,7 @@ describe('POST /recipes/images', () => {
     )
 
     const res = await uploadRequest(makeFormData(makeFile('pdf', 'doc.pdf', 'application/pdf')), USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif')
@@ -152,7 +152,7 @@ describe('DELETE /recipes/images', () => {
     )
 
     const res = await deleteRequest('', USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('Image key must not be empty')
@@ -164,7 +164,7 @@ describe('DELETE /recipes/images', () => {
     )
 
     const res = await deleteRequest('other/abc-123.jpg', USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('Invalid image key')

--- a/src/routes/ingredients.test.ts
+++ b/src/routes/ingredients.test.ts
@@ -54,7 +54,7 @@ describe('GET /ingredients', () => {
   it('returns 200 with all ingredients when no query param', async () => {
     const res = await request('/ingredients', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Ingredients retrieved')
     expect(body.data).toEqual(SAMPLE_INGREDIENTS)
@@ -64,7 +64,7 @@ describe('GET /ingredients', () => {
   it('returns all ingredients for empty query string', async () => {
     const res = await request('/ingredients?query=', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Ingredients retrieved')
     expect(vi.mocked(ingredientService.listIngredients)).toHaveBeenCalledOnce()
     expect(vi.mocked(ingredientService.searchIngredients)).not.toHaveBeenCalled()
@@ -73,7 +73,7 @@ describe('GET /ingredients', () => {
   it('returns all ingredients for whitespace-only query', async () => {
     const res = await request('/ingredients?query=   ', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Ingredients retrieved')
     expect(vi.mocked(ingredientService.listIngredients)).toHaveBeenCalledOnce()
     expect(vi.mocked(ingredientService.searchIngredients)).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('GET /ingredients', () => {
     vi.mocked(ingredientService.searchIngredients).mockResolvedValue([{ id: 1, name: 'Garlic' }])
     const res = await request('/ingredients?query=gar', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Ingredients queried')
     expect(body.data).toEqual([{ id: 1, name: 'Garlic' }])
     expect(vi.mocked(ingredientService.searchIngredients)).toHaveBeenCalledWith(
@@ -97,7 +97,7 @@ describe('GET /ingredients', () => {
     vi.mocked(ingredientService.searchIngredients).mockResolvedValue([])
     const res = await request('/ingredients?query=zzz', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Ingredients queried')
     expect(body.data).toEqual([])
   })

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -107,7 +107,7 @@ describe('GET /recipes', () => {
   it('returns 200 with paginated slim list', async () => {
     const res = await request('/recipes')
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Recipes retrieved')
     expect(body.data).toEqual(SAMPLE_LIST_ITEMS)
@@ -153,7 +153,7 @@ describe('GET /recipes', () => {
   it('routes to searchRecipes when filter params are present', async () => {
     const res = await request('/recipes?name=pasta&cuisineId=1')
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Recipes queried')
     expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
       expect.anything(),
@@ -165,6 +165,121 @@ describe('GET /recipes', () => {
   it('returns 401 when API key is missing', async () => {
     const res = await request('/recipes', { apiKey: null })
     expect(res.status).toBe(401)
+  })
+
+  describe('search mode', () => {
+    beforeEach(() => {
+      vi.mocked(recipeService.searchRecipes).mockResolvedValue(SAMPLE_LIST_ITEMS)
+    })
+
+    it('filters by name', async () => {
+      const res = await request('/recipes?name=pasta')
+      expect(res.status).toBe(200)
+      const body = await res.json() as Record<string, any>
+      expect(body.message).toBe('Recipes queried')
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: 'pasta' }),
+      )
+      expect(vi.mocked(recipeService.listRecipes)).not.toHaveBeenCalled()
+    })
+
+    it('filters by tag (text)', async () => {
+      const res = await request('/recipes?tag=quick')
+      expect(res.status).toBe(200)
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ tag: 'quick' }),
+      )
+    })
+
+    it('filters by cuisine (text)', async () => {
+      const res = await request('/recipes?cuisine=italian')
+      expect(res.status).toBe(200)
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ cuisine: 'italian' }),
+      )
+    })
+
+    it('filters by ingredient (text)', async () => {
+      const res = await request('/recipes?ingredient=garlic')
+      expect(res.status).toBe(200)
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ ingredient: 'garlic' }),
+      )
+    })
+
+    it('filters by cuisineId', async () => {
+      const res = await request('/recipes?cuisineId=3')
+      expect(res.status).toBe(200)
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ cuisineId: 3 }),
+      )
+    })
+
+    it('filters by tagId', async () => {
+      const res = await request('/recipes?tagId=7')
+      expect(res.status).toBe(200)
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ tagId: 7 }),
+      )
+    })
+
+    it('filters by ingredientId', async () => {
+      const res = await request('/recipes?ingredientId=42')
+      expect(res.status).toBe(200)
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ ingredientId: 42 }),
+      )
+    })
+
+    it('ANDs multiple filter params together', async () => {
+      const res = await request('/recipes?name=pasta&cuisineId=1&tag=quick')
+      expect(res.status).toBe(200)
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: 'pasta', cuisineId: 1, tag: 'quick' }),
+      )
+    })
+
+    it('blank ?name= still triggers search mode (service is responsible for ignoring it)', async () => {
+      const res = await request('/recipes?name=')
+      expect(res.status).toBe(200)
+      const body = await res.json() as Record<string, any>
+      expect(body.message).toBe('Recipes queried')
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: '' }),
+      )
+      expect(vi.mocked(recipeService.listRecipes)).not.toHaveBeenCalled()
+    })
+
+    it('whitespace-only ?name= still triggers search mode', async () => {
+      const res = await request('/recipes?name=%20%20%20')
+      expect(res.status).toBe(200)
+      const body = await res.json() as Record<string, any>
+      expect(body.message).toBe('Recipes queried')
+      expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: '   ' }),
+      )
+      expect(vi.mocked(recipeService.listRecipes)).not.toHaveBeenCalled()
+    })
+
+    it('returns slim { id, name, imageUrl } DTO shape', async () => {
+      const res = await request('/recipes?name=pasta')
+      const body = await res.json() as Record<string, any>
+      expect(body.data).toEqual(SAMPLE_LIST_ITEMS)
+      expect(body.data[0]).toMatchObject({ id: expect.any(Number), name: expect.any(String) })
+      expect(body.data[0]).toHaveProperty('imageUrl')
+      expect(body.data[0]).not.toHaveProperty('description')
+      expect(body.data[0]).not.toHaveProperty('ingredients')
+    })
   })
 })
 
@@ -179,7 +294,7 @@ describe('POST /recipes', () => {
     const res = await request('/recipes', { method: 'POST', body: SAVE_BODY })
     expect(res.status).toBe(201)
     expect(res.headers.get('Location')).toBe('/recipes/1')
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.status).toBe(201)
     expect(body.message).toBe('Recipe saved')
     expect(body.data.id).toBe(1)
@@ -194,7 +309,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, name: 'A' },
     })
     expect(res.status).toBe(400)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Recipe name must be between 2 to 150 characters.')
   })
 
@@ -204,7 +319,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, servings: 0 },
     })
     expect(res.status).toBe(400)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Servings must be a more than zero.')
   })
 
@@ -214,7 +329,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, cookingTime: -1 },
     })
     expect(res.status).toBe(400)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Cooking time cannot be negative.')
   })
 
@@ -224,7 +339,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, preparationTime: 0 },
     })
     expect(res.status).toBe(400)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Preparation time cannot be zero minutes.')
   })
 
@@ -234,7 +349,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, ingredients: [] },
     })
     expect(res.status).toBe(400)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('There must be at least one ingredient.')
   })
 
@@ -244,7 +359,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, steps: [] },
     })
     expect(res.status).toBe(400)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('There must be at least one step.')
   })
 
@@ -259,7 +374,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, cuisine: {} },
     })
     expect(res.status).toBe(400)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Cuisine request must have either an ID or a name.')
   })
 
@@ -269,7 +384,7 @@ describe('POST /recipes', () => {
     )
     const res = await request('/recipes', { method: 'POST', body: SAVE_BODY })
     expect(res.status).toBe(404)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Unit ID not found: 999')
   })
 })
@@ -281,7 +396,7 @@ describe('GET /recipes/:id', () => {
     vi.mocked(recipeService.getRecipe).mockResolvedValue(FULL_RECIPE)
     const res = await request('/recipes/1')
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Recipe retrieved')
     expect(body.data.id).toBe(1)
@@ -296,7 +411,7 @@ describe('GET /recipes/:id', () => {
     )
     const res = await request('/recipes/999')
     expect(res.status).toBe(404)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Recipe not found with id: 999')
   })
 
@@ -315,7 +430,7 @@ describe('PATCH /recipes/:id', () => {
     vi.mocked(recipeService.updateRecipe).mockResolvedValue(updated)
     const res = await request('/recipes/1', { method: 'PATCH', body: { name: 'Updated Pasta' } })
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Recipe updated')
     expect(body.data.name).toBe('Updated Pasta')
   })
@@ -384,7 +499,7 @@ describe('DELETE /recipes/:id', () => {
     )
     const res = await request('/recipes/999', { method: 'DELETE', apiKey: ADMIN_KEY })
     expect(res.status).toBe(404)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Recipe not found with id: 999')
   })
 

--- a/src/routes/tags.test.ts
+++ b/src/routes/tags.test.ts
@@ -54,7 +54,7 @@ describe('GET /tags', () => {
   it('returns 200 with all tags when no query param', async () => {
     const res = await request('/tags', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Tags retrieved')
     expect(body.data).toEqual(SAMPLE_TAGS)
@@ -64,7 +64,7 @@ describe('GET /tags', () => {
   it('returns all tags for empty query string', async () => {
     const res = await request('/tags?query=', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Tags retrieved')
     expect(vi.mocked(tagService.listTags)).toHaveBeenCalledOnce()
     expect(vi.mocked(tagService.searchTags)).not.toHaveBeenCalled()
@@ -73,7 +73,7 @@ describe('GET /tags', () => {
   it('returns all tags for whitespace-only query', async () => {
     const res = await request('/tags?query=   ', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Tags retrieved')
     expect(vi.mocked(tagService.listTags)).toHaveBeenCalledOnce()
     expect(vi.mocked(tagService.searchTags)).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('GET /tags', () => {
     vi.mocked(tagService.searchTags).mockResolvedValue([{ id: 1, name: 'Vegan' }])
     const res = await request('/tags?query=veg', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Tags queried')
     expect(body.data).toEqual([{ id: 1, name: 'Vegan' }])
     expect(vi.mocked(tagService.searchTags)).toHaveBeenCalledWith(expect.anything(), 'veg')
@@ -94,7 +94,7 @@ describe('GET /tags', () => {
     vi.mocked(tagService.searchTags).mockResolvedValue([])
     const res = await request('/tags?query=zzz', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.message).toBe('Tags queried')
     expect(body.data).toEqual([])
   })

--- a/src/routes/units.test.ts
+++ b/src/routes/units.test.ts
@@ -54,7 +54,7 @@ describe('GET /units', () => {
   it('returns 200 with all units', async () => {
     const res = await request('/units', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Units retrieved')
     expect(body.data).toEqual(SAMPLE_UNITS)
@@ -63,7 +63,7 @@ describe('GET /units', () => {
 
   it('includes null abbreviation in response', async () => {
     const res = await request('/units', USER_KEY)
-    const body = await res.json()
+    const body = await res.json() as Record<string, any>
     const piece = body.data.find((u: { id: number }) => u.id === 3)
     expect(piece.abbreviation).toBeNull()
   })

--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { listRecipes } from './recipeService'
+import { listRecipes, searchRecipes } from './recipeService'
 
 function makeDb(rows: { id: number; name: string; imageUrl: string | null }[]) {
   const chain = {
@@ -13,6 +13,140 @@ function makeDb(rows: { id: number; name: string; imageUrl: string | null }[]) {
     chain,
   }
 }
+
+// makeSearchDb returns a mock that handles both subquery builder calls (not awaited)
+// and the final query call (awaited). The chain is thenable so `await chain` resolves
+// to `rows`. Subqueries use the same chain object but are never awaited by the caller,
+// so `.then()` is not triggered for them.
+function makeSearchDb(rows: { id: number; name: string; imageUrl: string | null }[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    // Makes the chain awaitable: `await chain` calls chain.then(resolve) → resolve(rows)
+    then: vi.fn().mockImplementation((resolve: (v: unknown) => unknown) => resolve(rows)),
+  }
+  const db = {
+    select: vi.fn().mockReturnValue(chain),
+  } as unknown as Parameters<typeof searchRecipes>[0]
+  return { db, chain }
+}
+
+describe('searchRecipes', () => {
+  // For each text param, blank/whitespace values should be ignored (no conditions added).
+  // When no conditions are added, .where() is called with undefined and only the one
+  // final select() is made (no subqueries).
+  it('ignores blank name param', async () => {
+    const { db, chain } = makeSearchDb([])
+    await searchRecipes(db, { name: '' })
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(chain.where).toHaveBeenCalledWith(undefined)
+  })
+
+  it('ignores whitespace-only name param', async () => {
+    const { db, chain } = makeSearchDb([])
+    await searchRecipes(db, { name: '   ' })
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(chain.where).toHaveBeenCalledWith(undefined)
+  })
+
+  it('ignores blank tag param', async () => {
+    const { db, chain } = makeSearchDb([])
+    await searchRecipes(db, { tag: '' })
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(chain.where).toHaveBeenCalledWith(undefined)
+  })
+
+  it('ignores blank cuisine param', async () => {
+    const { db, chain } = makeSearchDb([])
+    await searchRecipes(db, { cuisine: '' })
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(chain.where).toHaveBeenCalledWith(undefined)
+  })
+
+  it('ignores blank ingredient param', async () => {
+    const { db, chain } = makeSearchDb([])
+    await searchRecipes(db, { ingredient: '' })
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(chain.where).toHaveBeenCalledWith(undefined)
+  })
+
+  // Text filters that use a direct column condition (no subquery)
+  it('applies name filter (1 select call, truthy WHERE)', async () => {
+    const { db, chain } = makeSearchDb([])
+    await searchRecipes(db, { name: 'pasta' })
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(chain.where).toHaveBeenCalledWith(expect.anything())
+    expect(chain.where.mock.calls[0][0]).toBeDefined()
+  })
+
+  // cuisineId is an exact-match direct condition — no subquery
+  it('applies cuisineId filter (1 select call, truthy WHERE)', async () => {
+    const { db, chain } = makeSearchDb([])
+    await searchRecipes(db, { cuisineId: 5 })
+    expect(db.select).toHaveBeenCalledTimes(1)
+    expect(chain.where.mock.calls[0][0]).toBeDefined()
+  })
+
+  // Cuisine text filter uses 1 subquery (cuisines table) → 2 total selects
+  it('applies cuisine text filter (2 select calls)', async () => {
+    const { db } = makeSearchDb([])
+    await searchRecipes(db, { cuisine: 'italian' })
+    expect(db.select).toHaveBeenCalledTimes(2)
+  })
+
+  // tagId uses 1 subquery (recipe_tags table) → 2 total selects
+  it('applies tagId filter (2 select calls)', async () => {
+    const { db } = makeSearchDb([])
+    await searchRecipes(db, { tagId: 3 })
+    expect(db.select).toHaveBeenCalledTimes(2)
+  })
+
+  // ingredientId uses 1 subquery (recipe_ingredients table) → 2 total selects
+  it('applies ingredientId filter (2 select calls)', async () => {
+    const { db } = makeSearchDb([])
+    await searchRecipes(db, { ingredientId: 7 })
+    expect(db.select).toHaveBeenCalledTimes(2)
+  })
+
+  // Tag text filter uses 2 subqueries (tags → recipe_tags) → 3 total selects
+  it('applies tag text filter (3 select calls)', async () => {
+    const { db } = makeSearchDb([])
+    await searchRecipes(db, { tag: 'quick' })
+    expect(db.select).toHaveBeenCalledTimes(3)
+  })
+
+  // Ingredient text filter uses 2 subqueries (ingredients → recipe_ingredients) → 3 total selects
+  it('applies ingredient text filter (3 select calls)', async () => {
+    const { db } = makeSearchDb([])
+    await searchRecipes(db, { ingredient: 'garlic' })
+    expect(db.select).toHaveBeenCalledTimes(3)
+  })
+
+  // Multiple filters AND together: name (0 subqueries) + tagId (1 subquery) = 2 selects
+  it('ANDs multiple filters (combined select call count)', async () => {
+    const { db } = makeSearchDb([])
+    await searchRecipes(db, { name: 'pasta', tagId: 2 })
+    expect(db.select).toHaveBeenCalledTimes(2)
+  })
+
+  it('maps null imageUrl to null in results', async () => {
+    const { db } = makeSearchDb([{ id: 1, name: 'Pasta', imageUrl: null }])
+    const result = await searchRecipes(db, {})
+    expect(result[0].imageUrl).toBeNull()
+  })
+
+  it('maps non-null imageUrl correctly', async () => {
+    const { db } = makeSearchDb([{ id: 1, name: 'Pasta', imageUrl: 'https://img.com/1.jpg' }])
+    const result = await searchRecipes(db, {})
+    expect(result[0].imageUrl).toBe('https://img.com/1.jpg')
+  })
+
+  it('returns empty array when no rows match', async () => {
+    const { db } = makeSearchDb([])
+    const result = await searchRecipes(db, { name: 'nonexistent' })
+    expect(result).toEqual([])
+  })
+})
 
 describe('listRecipes', () => {
   it('caps limit at 100', async () => {


### PR DESCRIPTION
## Summary

Ports the test coverage for `searchRecipes` (issue #14 — `RecipeSpecification` filtering). The implementation already landed in #33/#34; this PR adds the missing unit tests and fixes pre-existing TypeScript strict-mode errors that were blocking the build.

**Source references:** `RecipeSpecification.java`, `RecipeSearchParams.java`, `RecipeController.java` (recipe-service)

### What changed

- **`src/routes/recipes.test.ts`** — Added `describe('search mode')` block covering all 7 filter params in isolation (`name`, `tag`, `cuisine`, `ingredient`, `cuisineId`, `tagId`, `ingredientId`), combined filters (AND semantics), blank and whitespace-only param routing, and slim DTO shape verification
- **`src/services/recipeService.test.ts`** — Added `describe('searchRecipes')` covering blank/whitespace params being ignored at the service layer, each filter's subquery structure (verified via `db.select` call count), combined filters, and result mapping
- **`eslint.config.js`** — Added `@typescript-eslint/no-explicit-any: off` override for `**/*.test.ts`; `Response.json()` returns `unknown` under strict mode and test files legitimately need `any` for mocking and JSON assertion flexibility
- **All `*.test.ts` files** — Cast `await res.json()` to `Record<string, any>` to fix the TypeScript strict-mode build errors that existed project-wide

### How `makeSearchDb` works

The service-level mock uses a thenable chain: `db.select().from().where()` returns the same chain object via `mockReturnThis()`. Subqueries pass this chain as a value to `inArray()` (never awaited), so `.then()` is not triggered. The final `await db.select().from().where()` triggers `.then(resolve)` → resolves to the mocked rows. This lets one mock handle both paths cleanly.

## Review notes (from api-reviewer)

- **Should note:** `db.select` call-count assertions in service tests pin to the current subquery implementation. A future refactor to JOINs (closer to the Spring Boot source) would break these tests even with correct behavior — tracked as a known tradeoff since there's no integration test layer.
- **Should note:** `@typescript-eslint/no-explicit-any` is disabled for all test files rather than per-occurrence. An alternative would be to import `ApiSuccessResponse`/`ApiErrorResponse` from `src/lib/response.ts` and use those shapes — this would catch field-name typos on the envelope. Left as a follow-up.
- **Note:** Whitespace-only query params (e.g., `?name=%20%20%20`) still trigger search mode at the route layer (the route uses `!== undefined`); the service ignores them via `.trim()`. This matches the Java source behavior.

Closes #14