### PR TITLE
fix: accept null id on nested cuisine/ingredient/tag inputs

### DIFF
--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -368,6 +368,19 @@ describe('POST /recipes', () => {
     expect(res.status).toBe(201)
   })
 
+  it('accepts explicit null id on cuisine, ingredients, and tags', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: {
+        ...SAVE_BODY,
+        cuisine: { id: null, name: 'Italian' },
+        ingredients: [{ id: null, name: 'Spaghetti', unitId: 1, quantity: 200 }],
+        tags: [{ id: null, name: 'Quick' }],
+      },
+    })
+    expect(res.status).toBe(201)
+  })
+
   it('returns 400 when cuisine has neither id nor name', async () => {
     const res = await request('/recipes', {
       method: 'POST',
@@ -449,6 +462,19 @@ describe('PATCH /recipes/:id', () => {
     const res = await request('/recipes/1', { method: 'PATCH', body: { ingredients: [] } })
     expect(res.status).toBe(400)
     expect(vi.mocked(recipeService.updateRecipe)).not.toHaveBeenCalled()
+  })
+
+  it('accepts explicit null id on cuisine, ingredients, and tags', async () => {
+    vi.mocked(recipeService.updateRecipe).mockResolvedValue(FULL_RECIPE)
+    const res = await request('/recipes/1', {
+      method: 'PATCH',
+      body: {
+        cuisine: { id: null, name: 'Italian' },
+        ingredients: [{ id: null, name: 'Spaghetti', unitId: 1, quantity: 200 }],
+        tags: [{ id: null, name: 'Quick' }],
+      },
+    })
+    expect(res.status).toBe(200)
   })
 
   it('returns 400 when steps is an empty array', async () => {

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -16,7 +16,7 @@ export const recipeRouter = new Hono<{ Bindings: CloudflareBindings }>()
 
 const CuisineInputSchema = z
   .object({
-    id: z.number().int().positive().optional(),
+    id: z.number().int().positive().nullish(),
     name: z.string().optional(),
   })
   .refine((c) => c.id != null || (c.name?.trim().length ?? 0) > 0, {
@@ -25,7 +25,7 @@ const CuisineInputSchema = z
 
 const IngredientInputSchema = z
   .object({
-    id: z.number().int().positive().optional(),
+    id: z.number().int().positive().nullish(),
     name: z.string().optional(),
     unitId: z.number().int().positive(),
     quantity: z.number().positive(),
@@ -37,7 +37,7 @@ const IngredientInputSchema = z
 
 const TagInputSchema = z
   .object({
-    id: z.number().int().positive().optional(),
+    id: z.number().int().positive().nullish(),
     name: z.string().optional(),
   })
   .refine((t) => t.id != null || (t.name?.trim().length ?? 0) > 0, {

--- a/src/services/cuisine-service.ts
+++ b/src/services/cuisine-service.ts
@@ -23,7 +23,7 @@ export async function searchCuisines(db: Db, query: string): Promise<NamedEntity
   return rows.map(toResponse)
 }
 
-export async function resolveCuisine(db: Db, id?: number, name?: string): Promise<Cuisine> {
+export async function resolveCuisine(db: Db, id?: number | null, name?: string): Promise<Cuisine> {
   if (id == null && !name?.trim()) {
     throw new BadRequestError('Cuisine request must have either an ID or a name.')
   }

--- a/src/services/ingredient-service.ts
+++ b/src/services/ingredient-service.ts
@@ -23,7 +23,11 @@ export async function searchIngredients(db: Db, query: string): Promise<NamedEnt
   return rows.map(toResponse)
 }
 
-export async function resolveIngredient(db: Db, id?: number, name?: string): Promise<Ingredient> {
+export async function resolveIngredient(
+  db: Db,
+  id?: number | null,
+  name?: string,
+): Promise<Ingredient> {
   if (id == null && !name?.trim()) {
     throw new BadRequestError('Ingredient request must have either an ID or a name.')
   }

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -17,15 +17,15 @@ import { resolveUnit } from './unit-service'
 
 type Db = ReturnType<typeof createDb>
 
-export type CuisineInput = { id?: number; name?: string }
+export type CuisineInput = { id?: number | null; name?: string }
 export type IngredientInput = {
-  id?: number
+  id?: number | null
   name?: string
   unitId: number
   quantity: number
   notes?: string | null
 }
-export type TagInput = { id?: number; name?: string }
+export type TagInput = { id?: number | null; name?: string }
 export type StepInput = { stepNumber: number; description: string; tip?: string | null }
 
 export type RecipeSaveInput = {

--- a/src/services/tag-service.ts
+++ b/src/services/tag-service.ts
@@ -23,7 +23,7 @@ export async function searchTags(db: Db, query: string): Promise<NamedEntityResp
   return rows.map(toResponse)
 }
 
-export async function resolveTag(db: Db, id?: number, name?: string): Promise<Tag> {
+export async function resolveTag(db: Db, id?: number | null, name?: string): Promise<Tag> {
   if (id == null && !name?.trim()) {
     throw new BadRequestError('Tag request must have either an ID or a name.')
   }


### PR DESCRIPTION
## Summary
- `CuisineInputSchema`, `IngredientInputSchema`, and `TagInputSchema` in `src/routes/recipes.ts` declared `id` as `.optional()`, which only accepts `undefined` and rejects an explicit `null`
- Clients sending `id: null` for a new nested item (a common "placeholder row" pattern) got a 400 on `POST`/`PATCH /recipes`
- Switched `id` to `.nullish()` on all three schemas, matching how the rest of the schema already treats optional values (`notes`, `tip`, `calories`, `imageUrl` all use `.nullish()`/`.nullable().optional()`)
- Widened the corresponding service-layer types (`CuisineInput`, `IngredientInput`, `TagInput`) and `resolve*()` signatures in `cuisine-service.ts`, `ingredient-service.ts`, and `tag-service.ts` to accept `number | null | undefined`

## Test plan
- [x] Added a `POST /recipes` test asserting `id: null` on cuisine/ingredients/tags succeeds (201)
- [x] Added a `PATCH /recipes/:id` test asserting the same (200)
- [x] `pnpm test` — 138 tests passing
- [x] `pnpm run lint` — clean
- [x] `npx tsc --noEmit` — no new type errors (one pre-existing, unrelated error in `image-service.test.ts` predates this branch)

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)