### PR TITLE
feat: point R2_PUBLIC_URL at custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ All variables are injected at runtime via Cloudflare secrets (production) or `.d
 
 `R2_PUBLIC_URL` and `IMAGE_BUCKET` are configured in `wrangler.jsonc` and do not need to be set as secrets.
 
+`R2_PUBLIC_URL` points at a custom domain (`cdn.foodiesfinds.com`) connected to the `recipe-images`
+R2 bucket. Connecting a custom domain to an R2 bucket is a Cloudflare dashboard-only step (R2 →
+`recipe-images` → Settings → Custom Domains) and isn't something `wrangler.jsonc` can provision —
+if you're setting this up fresh, connect the domain there before deploying, otherwise requests to
+`R2_PUBLIC_URL` will 404.
+
 ## Local development
 
 ```bash

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,7 +11,7 @@
     }
   ],
   "vars": {
-    "R2_PUBLIC_URL": "https://pub-017886dc539b41789e7c76de04239c5d.r2.dev"
+    "R2_PUBLIC_URL": "https://cdn.foodiesfinds.com"
   },
   // "kv_namespaces": [
   //   {


### PR DESCRIPTION
Replaces the pub-*.r2.dev testing domain with cdn.foodiesfinds.com. The dev domain is uncached/rate-limited; a custom domain enables Cloudflare's CDN caching, cache rules, and analytics for production image traffic.

Closes #41