### PR TITLE
Add presigned R2 upload URLs for images

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,1 +1,4 @@
 DATABASE_URL=postgresql://user:password@host/dbname
+R2_ACCOUNT_ID=your-cloudflare-account-id
+R2_ACCESS_KEY_ID=your-r2-api-token-access-key-id
+R2_SECRET_ACCESS_KEY=your-r2-api-token-secret-access-key

--- a/README.md
+++ b/README.md
@@ -14,13 +14,32 @@ Requests are rate limited to **60 per minute per API key**. Exceeding the limit 
 
 All variables are injected at runtime via Cloudflare secrets (production) or `.dev.vars` (local).
 
-| Variable        | Description                                          |
-| --------------- | ---------------------------------------------------- |
-| `DATABASE_URL`  | Postgres connection string (Supabase)                |
-| `USER_API_KEY`  | API key for standard access (`X-Api-Key` header)     |
-| `ADMIN_API_KEY` | API key for admin routes (e.g. `DELETE /recipes/:id`) |
+| Variable                | Description                                                     |
+| ----------------------- | ---------------------------------------------------------------- |
+| `DATABASE_URL`          | Postgres connection string (Supabase)                            |
+| `USER_API_KEY`          | API key for standard access (`X-Api-Key` header)                 |
+| `ADMIN_API_KEY`         | API key for admin routes (e.g. `DELETE /recipes/:id`)            |
+| `R2_ACCOUNT_ID`         | Cloudflare account ID — used to build the R2 S3-compatible endpoint |
+| `R2_ACCESS_KEY_ID`      | R2 API token access key ID, scoped to the `recipe-images` bucket |
+| `R2_SECRET_ACCESS_KEY`  | R2 API token secret access key                                   |
 
-`R2_PUBLIC_URL` and `IMAGE_BUCKET` are configured in `wrangler.jsonc` and do not need to be set as secrets.
+`R2_PUBLIC_URL`, `R2_BUCKET_NAME`, and `IMAGE_BUCKET` are configured in `wrangler.jsonc` and do not
+need to be set as secrets.
+
+### Presigned image uploads
+
+`POST /recipes/images/presign` returns a short-lived, single-use presigned PUT URL so clients
+upload images directly to R2 instead of routing the file through this API. Generating it requires
+an **R2 API token** (Access Key ID / Secret Access Key), separate from your Cloudflare account
+credentials:
+
+1. Cloudflare dashboard → R2 → **Manage API tokens** → Create API token
+2. Scope it to **Object Read & Write**, restricted to the `recipe-images` bucket
+3. Copy the Access Key ID, Secret Access Key, and your Account ID into the secrets above
+
+The old `POST /recipes/images` (server-mediated multipart upload) is now deprecated — it returns a
+`Deprecation` header pointing at the presign endpoint — but stays functional until callers (e.g.
+foodies-finds) migrate to the presigned flow.
 
 ## Local development
 
@@ -41,6 +60,9 @@ pnpm dev
 pnpm exec wrangler secret put DATABASE_URL
 pnpm exec wrangler secret put USER_API_KEY
 pnpm exec wrangler secret put ADMIN_API_KEY
+pnpm exec wrangler secret put R2_ACCOUNT_ID
+pnpm exec wrangler secret put R2_ACCESS_KEY_ID
+pnpm exec wrangler secret put R2_SECRET_ACCESS_KEY
 ```
 
 3. Verify the `recipe-images` R2 bucket exists in your Cloudflare account. If not: `pnpm exec wrangler r2 bucket create recipe-images`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ The old `POST /recipes/images` (server-mediated multipart upload) is now depreca
 `Deprecation` header pointing at the presign endpoint — but stays functional until callers (e.g.
 foodies-finds) migrate to the presigned flow.
 
+### Image URL storage
+
+`recipes.imageUrl` stores the R2 **key** (e.g. `recipes/<uuid>.jpg`), not a full URL — clients
+should submit the presign response's `key` (not its `imageUrl`) as the recipe's `imageUrl` field.
+`R2_PUBLIC_URL` is prepended on every read (`GET /recipes`, `GET /recipes/:id`, search, and the
+`POST`/`PATCH` responses), so a future domain change (see #41) never requires rewriting existing
+rows. Rows written before this change still hold a full URL and are returned unchanged — no
+migration is required, though existing rows can optionally be backfilled to bare keys for
+consistency.
+
 ## Local development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1116.0",
+    "@aws-sdk/s3-request-presigner": "^3.1116.0",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.32",
     "postgres": "^3.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1116.0
+        version: 3.1116.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1116.0
+        version: 3.1116.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.1.0)(postgres@3.4.9)
@@ -50,6 +56,82 @@ importers:
         version: 4.115.0
 
 packages:
+
+  '@aws-sdk/checksums@3.1000.29':
+    resolution: {integrity: sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1116.0':
+    resolution: {integrity: sha512-UKRl9qSVW0rZpvSOauQNpYAy8+ONBAVYnpfKVtCyOF+FZVT1tl6MunYuHvuarCrroD2/YJs+tHTALYNgAlec3Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    resolution: {integrity: sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1116.0':
+    resolution: {integrity: sha512-WwaaVpvrZyML5L8SNY7sUGsYlMeCHzQ/8A/ms7dz/7sfYRvPn+qf0OasUWk+zuT8qGwjsYhILD0WVtlqUU08pQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -891,6 +973,30 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
   '@speed-highlight/core@1.2.17':
     resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
@@ -1026,6 +1132,9 @@ packages:
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -1732,6 +1841,180 @@ packages:
 
 snapshots:
 
+  '@aws-sdk/checksums@3.1000.29':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1116.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.29
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/middleware-sdk-s3': 3.972.75
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)':
@@ -2222,6 +2505,39 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -2393,6 +2709,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   blake3-wasm@2.1.5: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2883,8 +3201,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.23.9:
     dependencies:

--- a/src/lib/image-constraints.ts
+++ b/src/lib/image-constraints.ts
@@ -1,0 +1,24 @@
+export const MAX_IMAGE_SIZE = 25 * 1024 * 1024 // 25 MB
+
+export const ALLOWED_IMAGE_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+])
+
+const EXTENSION_BY_TYPE: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/heic': 'heic',
+  'image/heif': 'heif',
+}
+
+export function buildImageKey(contentType: string): string {
+  const ext = EXTENSION_BY_TYPE[contentType] ?? 'jpg'
+  return `recipes/${crypto.randomUUID()}.${ext}`
+}

--- a/src/lib/image-url.test.ts
+++ b/src/lib/image-url.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { toPublicUrl, toStorageKey, withPublicImageUrl } from './image-url'
+
+const PUBLIC_URL = 'https://cdn.foodiesfinds.com'
+
+describe('toStorageKey', () => {
+  it('strips a matching public URL prefix', () => {
+    expect(toStorageKey(`${PUBLIC_URL}/recipes/abc-123.jpg`, PUBLIC_URL)).toBe(
+      'recipes/abc-123.jpg',
+    )
+  })
+
+  it('strips the prefix even if publicUrl has a trailing slash', () => {
+    expect(toStorageKey(`${PUBLIC_URL}/recipes/abc-123.jpg`, `${PUBLIC_URL}/`)).toBe(
+      'recipes/abc-123.jpg',
+    )
+  })
+
+  it('leaves an already-bare key untouched', () => {
+    expect(toStorageKey('recipes/abc-123.jpg', PUBLIC_URL)).toBe('recipes/abc-123.jpg')
+  })
+
+  it('leaves a URL from a different host untouched', () => {
+    const other = 'https://pub-017886dc539b41789e7c76de04239c5d.r2.dev/recipes/abc-123.jpg'
+    expect(toStorageKey(other, PUBLIC_URL)).toBe(other)
+  })
+})
+
+describe('toPublicUrl', () => {
+  it('returns null for a null stored value', () => {
+    expect(toPublicUrl(null, PUBLIC_URL)).toBeNull()
+  })
+
+  it('prefixes a bare key with the public URL', () => {
+    expect(toPublicUrl('recipes/abc-123.jpg', PUBLIC_URL)).toBe(
+      `${PUBLIC_URL}/recipes/abc-123.jpg`,
+    )
+  })
+
+  it('strips a trailing slash from publicUrl before prefixing', () => {
+    expect(toPublicUrl('recipes/abc-123.jpg', `${PUBLIC_URL}/`)).toBe(
+      `${PUBLIC_URL}/recipes/abc-123.jpg`,
+    )
+  })
+
+  it('leaves an already-absolute stored value untouched (pre-migration rows)', () => {
+    const legacy = 'https://pub-017886dc539b41789e7c76de04239c5d.r2.dev/recipes/abc-123.jpg'
+    expect(toPublicUrl(legacy, PUBLIC_URL)).toBe(legacy)
+  })
+})
+
+describe('withPublicImageUrl', () => {
+  it('resolves imageUrl on the given item without mutating the input', () => {
+    const item = { id: 1, name: 'Pasta', imageUrl: 'recipes/abc-123.jpg' }
+
+    const result = withPublicImageUrl(item, PUBLIC_URL)
+
+    expect(result).toEqual({ id: 1, name: 'Pasta', imageUrl: `${PUBLIC_URL}/recipes/abc-123.jpg` })
+    expect(item.imageUrl).toBe('recipes/abc-123.jpg')
+  })
+
+  it('passes through a null imageUrl', () => {
+    const item = { id: 1, name: 'Pasta', imageUrl: null }
+    expect(withPublicImageUrl(item, PUBLIC_URL).imageUrl).toBeNull()
+  })
+})

--- a/src/lib/image-url.ts
+++ b/src/lib/image-url.ts
@@ -1,0 +1,22 @@
+// recipes.imageUrl stores an R2 key (e.g. "recipes/<uuid>.jpg") going forward, resolved to a
+// full URL at read time so a future public-domain change (see #41) never requires rewriting
+// existing rows. Rows written before this change still hold a full URL; toPublicUrl leaves an
+// already-absolute value untouched instead of forcing a one-time migration.
+
+export function toStorageKey(imageUrl: string, publicUrl: string): string {
+  const base = publicUrl.replace(/\/$/, '')
+  return imageUrl.startsWith(`${base}/`) ? imageUrl.slice(base.length + 1) : imageUrl
+}
+
+export function toPublicUrl(stored: string | null, publicUrl: string): string | null {
+  if (!stored) return null
+  if (/^https?:\/\//i.test(stored)) return stored
+  return `${publicUrl.replace(/\/$/, '')}/${stored}`
+}
+
+export function withPublicImageUrl<T extends { imageUrl: string | null }>(
+  item: T,
+  publicUrl: string,
+): T {
+  return { ...item, imageUrl: toPublicUrl(item.imageUrl, publicUrl) }
+}

--- a/src/routes/images.test.ts
+++ b/src/routes/images.test.ts
@@ -4,15 +4,21 @@ import { BadRequestError } from '../errors'
 import { authMiddleware } from '../middleware/auth'
 import { errorHandler } from '../middleware/error-handler'
 import * as imageService from '../services/image-service'
+import * as presignService from '../services/presign-service'
 import { imageRouter } from './images'
 
 vi.mock('../services/image-service')
+vi.mock('../services/presign-service')
 
 type TestBindings = {
   USER_API_KEY: string
   ADMIN_API_KEY: string
   IMAGE_BUCKET: R2Bucket
   R2_PUBLIC_URL: string
+  R2_BUCKET_NAME: string
+  R2_ACCOUNT_ID: string
+  R2_ACCESS_KEY_ID: string
+  R2_SECRET_ACCESS_KEY: string
 }
 
 const USER_KEY = 'test-user-key'
@@ -22,6 +28,10 @@ const TEST_ENV: TestBindings = {
   ADMIN_API_KEY: ADMIN_KEY,
   IMAGE_BUCKET: {} as unknown as R2Bucket,
   R2_PUBLIC_URL: 'https://pub-test.r2.dev',
+  R2_BUCKET_NAME: 'recipe-images',
+  R2_ACCOUNT_ID: 'test-account',
+  R2_ACCESS_KEY_ID: 'test-key-id',
+  R2_SECRET_ACCESS_KEY: 'test-secret',
 }
 
 const UPLOADED_URL = 'https://pub-test.r2.dev/recipes/abc-123.jpg'
@@ -48,6 +58,16 @@ function deleteRequest(key: string, apiKey?: string | null) {
   return app.request(
     `/recipes/images?key=${encodeURIComponent(key)}`,
     { method: 'DELETE', headers },
+    TEST_ENV,
+  )
+}
+
+function presignRequest(body: unknown, apiKey?: string | null) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (apiKey != null) headers['X-Api-Key'] = apiKey
+  return app.request(
+    '/recipes/images/presign',
+    { method: 'POST', body: JSON.stringify(body), headers },
     TEST_ENV,
   )
 }
@@ -84,6 +104,15 @@ describe('POST /recipes/images', () => {
     expect(res.status).toBe(200)
     expect(body.message).toBe('Image uploaded')
     expect(body.data).toBe(UPLOADED_URL)
+  })
+
+  it('marks the endpoint deprecated in favor of the presign endpoint', async () => {
+    vi.mocked(imageService.uploadImage).mockResolvedValue(UPLOADED_URL)
+
+    const res = await uploadRequest(makeFormData(makeFile()), USER_KEY)
+
+    expect(res.headers.get('Deprecation')).toBe('true')
+    expect(res.headers.get('Link')).toBe('</recipes/images/presign>; rel="successor-version"')
   })
 
   it('returns 400 when file field is missing from form', async () => {
@@ -180,5 +209,69 @@ describe('DELETE /recipes/images', () => {
 
     const res = await deleteRequest('recipes/abc-123.jpg', USER_KEY)
     expect(res.status).toBe(204)
+  })
+})
+
+describe('POST /recipes/images/presign', () => {
+  const PRESIGNED_RESULT = {
+    uploadUrl: 'https://test-account.r2.cloudflarestorage.com/signed',
+    key: 'recipes/abc-123.jpg',
+    imageUrl: 'https://pub-test.r2.dev/recipes/abc-123.jpg',
+  }
+
+  it('returns 200 with the presigned upload payload on a valid request', async () => {
+    vi.mocked(presignService.createPresignedUpload).mockResolvedValue(PRESIGNED_RESULT)
+
+    const res = await presignRequest({ contentType: 'image/jpeg', contentLength: 1024 }, USER_KEY)
+    const body = (await res.json()) as Record<string, any>
+
+    expect(res.status).toBe(200)
+    expect(body.message).toBe('Presigned upload URL created')
+    expect(body.data).toEqual(PRESIGNED_RESULT)
+    expect(vi.mocked(presignService.createPresignedUpload)).toHaveBeenCalledWith(
+      {
+        accountId: TEST_ENV.R2_ACCOUNT_ID,
+        accessKeyId: TEST_ENV.R2_ACCESS_KEY_ID,
+        secretAccessKey: TEST_ENV.R2_SECRET_ACCESS_KEY,
+        publicUrl: TEST_ENV.R2_PUBLIC_URL,
+      },
+      TEST_ENV.R2_BUCKET_NAME,
+      'image/jpeg',
+      1024,
+    )
+  })
+
+  it('returns 400 for a missing contentType (validation error)', async () => {
+    const res = await presignRequest({ contentLength: 1024 }, USER_KEY)
+
+    expect(res.status).toBe(400)
+    expect(vi.mocked(presignService.createPresignedUpload)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a non-positive contentLength (validation error)', async () => {
+    const res = await presignRequest({ contentType: 'image/jpeg', contentLength: 0 }, USER_KEY)
+
+    expect(res.status).toBe(400)
+    expect(vi.mocked(presignService.createPresignedUpload)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the service rejects an unsupported file type', async () => {
+    vi.mocked(presignService.createPresignedUpload).mockRejectedValue(
+      new BadRequestError('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif'),
+    )
+
+    const res = await presignRequest(
+      { contentType: 'application/pdf', contentLength: 1024 },
+      USER_KEY,
+    )
+    const body = (await res.json()) as Record<string, any>
+
+    expect(res.status).toBe(400)
+    expect(body.message).toBe('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif')
+  })
+
+  it('returns 401 when API key is missing', async () => {
+    const res = await presignRequest({ contentType: 'image/jpeg', contentLength: 1024 }, null)
+    expect(res.status).toBe(401)
   })
 })

--- a/src/routes/images.ts
+++ b/src/routes/images.ts
@@ -1,11 +1,20 @@
 import { Hono } from 'hono'
+import { z } from 'zod'
 import { BadRequestError } from '../errors'
 import { buildSuccess } from '../lib/response'
 import { requestLogger } from '../middleware/request-logger'
 import { deleteImage, uploadImage } from '../services/image-service'
+import { createPresignedUpload } from '../services/presign-service'
 
 export const imageRouter = new Hono<{ Bindings: CloudflareBindings }>()
 
+const PresignRequestSchema = z.object({
+  contentType: z.string().min(1),
+  contentLength: z.number().int().positive(),
+})
+
+// Deprecated: server-mediated upload. Use POST /presign instead — the client
+// uploads directly to R2 and this endpoint will be removed once callers migrate.
 imageRouter.post('/', requestLogger('image upload'), async (c) => {
   const formData = await c.req.formData()
   const file = formData.get('file')
@@ -15,7 +24,28 @@ imageRouter.post('/', requestLogger('image upload'), async (c) => {
   }
 
   const url = await uploadImage(c.env.IMAGE_BUCKET, c.env.R2_PUBLIC_URL, file)
+  c.header('Deprecation', 'true')
+  c.header('Link', '</recipes/images/presign>; rel="successor-version"')
   return c.json(buildSuccess(200, 'Image uploaded', url), 200)
+})
+
+imageRouter.post('/presign', requestLogger('image presign'), async (c) => {
+  const body = await c.req.json()
+  const { contentType, contentLength } = PresignRequestSchema.parse(body)
+
+  const data = await createPresignedUpload(
+    {
+      accountId: c.env.R2_ACCOUNT_ID,
+      accessKeyId: c.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: c.env.R2_SECRET_ACCESS_KEY,
+      publicUrl: c.env.R2_PUBLIC_URL,
+    },
+    c.env.R2_BUCKET_NAME,
+    contentType,
+    contentLength,
+  )
+
+  return c.json(buildSuccess(200, 'Presigned upload URL created', data), 200)
 })
 
 imageRouter.delete('/', requestLogger('image delete'), async (c) => {

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -13,6 +13,7 @@ type TestBindings = {
   USER_API_KEY: string
   ADMIN_API_KEY: string
   DATABASE_URL: string
+  R2_PUBLIC_URL: string
 }
 
 const USER_KEY = 'test-user-key'
@@ -21,6 +22,7 @@ const TEST_ENV: TestBindings = {
   USER_API_KEY: USER_KEY,
   ADMIN_API_KEY: ADMIN_KEY,
   DATABASE_URL: 'postgresql://test',
+  R2_PUBLIC_URL: 'https://pub-test.r2.dev',
 }
 
 const SAMPLE_LIST_ITEMS: recipeService.RecipeListItem[] = [
@@ -112,6 +114,15 @@ describe('GET /recipes', () => {
     expect(body.message).toBe('Recipes retrieved')
     expect(body.data).toEqual(SAMPLE_LIST_ITEMS)
     expect(vi.mocked(recipeService.listRecipes)).toHaveBeenCalledWith(expect.anything(), 0, 12)
+  })
+
+  it('resolves a bare stored key to a full public URL', async () => {
+    vi.mocked(recipeService.listRecipes).mockResolvedValue([
+      { id: 3, name: 'Tacos', imageUrl: 'recipes/xyz-789.jpg' },
+    ])
+    const res = await request('/recipes')
+    const body = await res.json() as Record<string, any>
+    expect(body.data[0].imageUrl).toBe(`${TEST_ENV.R2_PUBLIC_URL}/recipes/xyz-789.jpg`)
   })
 
   it('passes custom page and limit params', async () => {
@@ -303,6 +314,30 @@ describe('POST /recipes', () => {
     expect(body.data.steps).toHaveLength(1)
   })
 
+  it('strips the public URL prefix before storing a presigned imageUrl', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, imageUrl: `${TEST_ENV.R2_PUBLIC_URL}/recipes/xyz-789.jpg` },
+    })
+    expect(res.status).toBe(201)
+    expect(vi.mocked(recipeService.createRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ imageUrl: 'recipes/xyz-789.jpg' }),
+    )
+  })
+
+  it('stores an already-bare imageUrl key unchanged', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, imageUrl: 'recipes/xyz-789.jpg' },
+    })
+    expect(res.status).toBe(201)
+    expect(vi.mocked(recipeService.createRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ imageUrl: 'recipes/xyz-789.jpg' }),
+    )
+  })
+
   it('returns 400 when name is too short', async () => {
     const res = await request('/recipes', {
       method: 'POST',
@@ -455,6 +490,29 @@ describe('PATCH /recipes/:id', () => {
       expect.anything(),
       1,
       expect.objectContaining({ calories: null }),
+    )
+  })
+
+  it('strips the public URL prefix before storing a presigned imageUrl', async () => {
+    vi.mocked(recipeService.updateRecipe).mockResolvedValue(FULL_RECIPE)
+    await request('/recipes/1', {
+      method: 'PATCH',
+      body: { imageUrl: `${TEST_ENV.R2_PUBLIC_URL}/recipes/xyz-789.jpg` },
+    })
+    expect(vi.mocked(recipeService.updateRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      1,
+      expect.objectContaining({ imageUrl: 'recipes/xyz-789.jpg' }),
+    )
+  })
+
+  it('leaves an explicit null imageUrl untouched (nullifies the field)', async () => {
+    vi.mocked(recipeService.updateRecipe).mockResolvedValue(FULL_RECIPE)
+    await request('/recipes/1', { method: 'PATCH', body: { imageUrl: null } })
+    expect(vi.mocked(recipeService.updateRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      1,
+      expect.objectContaining({ imageUrl: null }),
     )
   })
 

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { createDb } from '../db/client'
 import { buildSuccess } from '../lib/response'
 import { BadRequestError } from '../errors'
+import { toStorageKey, withPublicImageUrl } from '../lib/image-url'
 import { requestLogger } from '../middleware/request-logger'
 import {
   createRecipe,
@@ -128,7 +129,14 @@ recipeRouter.get('/', async (c) => {
 
   if (hasFilter) {
     const data = await searchRecipes(db, { name, tag, cuisine, ingredient, tagId, cuisineId, ingredientId })
-    return c.json(buildSuccess(200, 'Recipes queried', data), 200)
+    return c.json(
+      buildSuccess(
+        200,
+        'Recipes queried',
+        data.map((r) => withPublicImageUrl(r, c.env.R2_PUBLIC_URL)),
+      ),
+      200,
+    )
   }
 
   const page = Number(c.req.query('page') ?? 0)
@@ -137,15 +145,23 @@ recipeRouter.get('/', async (c) => {
     throw new BadRequestError('Invalid page or limit')
   }
   const data = await listRecipes(db, page, limit)
-  return c.json(buildSuccess(200, 'Recipes retrieved', data), 200)
+  return c.json(
+    buildSuccess(
+      200,
+      'Recipes retrieved',
+      data.map((r) => withPublicImageUrl(r, c.env.R2_PUBLIC_URL)),
+    ),
+    200,
+  )
 })
 
 recipeRouter.post('/', requestLogger('recipe upload'), async (c) => {
   const db = createDb(c.env.DATABASE_URL)
   const body = await c.req.json()
   const input = RecipeSaveSchema.parse(body)
+  if (input.imageUrl) input.imageUrl = toStorageKey(input.imageUrl, c.env.R2_PUBLIC_URL)
   const data = await createRecipe(db, input)
-  return c.json(buildSuccess(201, 'Recipe saved', data), 201, {
+  return c.json(buildSuccess(201, 'Recipe saved', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)), 201, {
     Location: `/recipes/${data.id}`,
   })
 })
@@ -155,7 +171,7 @@ recipeRouter.get('/:id', async (c) => {
   if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
   const db = createDb(c.env.DATABASE_URL)
   const data = await getRecipe(db, id)
-  return c.json(buildSuccess(200, 'Recipe retrieved', data), 200)
+  return c.json(buildSuccess(200, 'Recipe retrieved', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)), 200)
 })
 
 recipeRouter.patch('/:id', requestLogger('recipe save'), async (c) => {
@@ -164,8 +180,9 @@ recipeRouter.patch('/:id', requestLogger('recipe save'), async (c) => {
   const db = createDb(c.env.DATABASE_URL)
   const body = await c.req.json()
   const input = RecipeUpdateSchema.parse(body)
+  if (input.imageUrl) input.imageUrl = toStorageKey(input.imageUrl, c.env.R2_PUBLIC_URL)
   const data = await updateRecipe(db, id, input)
-  return c.json(buildSuccess(200, 'Recipe updated', data), 200)
+  return c.json(buildSuccess(200, 'Recipe updated', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)), 200)
 })
 
 recipeRouter.delete('/:id', async (c) => {

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -1,24 +1,5 @@
 import { BadRequestError } from '../errors'
-
-const MAX_FILE_SIZE = 25 * 1024 * 1024 // 25 MB
-
-const ALLOWED_TYPES = new Set([
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-  'image/heic',
-  'image/heif',
-])
-
-const EXTENSION_MAP: Record<string, string> = {
-  'image/jpeg': 'jpg',
-  'image/png': 'png',
-  'image/webp': 'webp',
-  'image/gif': 'gif',
-  'image/heic': 'heic',
-  'image/heif': 'heif',
-}
+import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE, buildImageKey } from '../lib/image-constraints'
 
 export async function uploadImage(
   bucket: R2Bucket,
@@ -29,17 +10,16 @@ export async function uploadImage(
     throw new BadRequestError('File must not be empty')
   }
 
-  if (file.size > MAX_FILE_SIZE) {
+  if (file.size > MAX_IMAGE_SIZE) {
     throw new BadRequestError('File exceeds 25MB limit')
   }
 
   const contentType = file.type
-  if (!ALLOWED_TYPES.has(contentType)) {
+  if (!ALLOWED_IMAGE_TYPES.has(contentType)) {
     throw new BadRequestError('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif')
   }
 
-  const ext = EXTENSION_MAP[contentType] ?? 'jpg'
-  const key = `recipes/${crypto.randomUUID()}.${ext}`
+  const key = buildImageKey(contentType)
 
   await bucket.put(key, await file.arrayBuffer(), { httpMetadata: { contentType } })
 

--- a/src/services/presign-service.test.ts
+++ b/src/services/presign-service.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../errors'
+
+const getSignedUrlMock = vi.fn()
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (...args: unknown[]) => getSignedUrlMock(...args),
+}))
+
+const { createPresignedUpload } = await import('./presign-service')
+
+const CREDENTIALS = {
+  accountId: 'test-account',
+  accessKeyId: 'test-key-id',
+  secretAccessKey: 'test-secret',
+  publicUrl: 'https://pub-test.r2.dev',
+}
+const BUCKET = 'recipe-images'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createPresignedUpload', () => {
+  it('throws BadRequestError for an unsupported MIME type', async () => {
+    await expect(
+      createPresignedUpload(CREDENTIALS, BUCKET, 'application/pdf', 1024),
+    ).rejects.toThrow(
+      new BadRequestError('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif'),
+    )
+    expect(getSignedUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('throws BadRequestError for a non-positive contentLength', async () => {
+    await expect(createPresignedUpload(CREDENTIALS, BUCKET, 'image/jpeg', 0)).rejects.toThrow(
+      new BadRequestError('contentLength must be greater than 0'),
+    )
+    expect(getSignedUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('throws BadRequestError for contentLength exceeding 25MB', async () => {
+    await expect(
+      createPresignedUpload(CREDENTIALS, BUCKET, 'image/jpeg', 25 * 1024 * 1024 + 1),
+    ).rejects.toThrow(new BadRequestError('File exceeds 25MB limit'))
+    expect(getSignedUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a presigned upload URL, key, and public image URL', async () => {
+    getSignedUrlMock.mockResolvedValue('https://test-account.r2.cloudflarestorage.com/signed')
+
+    const result = await createPresignedUpload(CREDENTIALS, BUCKET, 'image/png', 1024)
+
+    expect(result.uploadUrl).toBe('https://test-account.r2.cloudflarestorage.com/signed')
+    expect(result.key).toMatch(/^recipes\/[\w-]+\.png$/)
+    expect(result.imageUrl).toBe(`${CREDENTIALS.publicUrl}/${result.key}`)
+  })
+
+  it('strips a trailing slash from publicUrl before building imageUrl', async () => {
+    getSignedUrlMock.mockResolvedValue('https://test-account.r2.cloudflarestorage.com/signed')
+
+    const result = await createPresignedUpload(
+      { ...CREDENTIALS, publicUrl: 'https://pub-test.r2.dev/' },
+      BUCKET,
+      'image/jpeg',
+      1024,
+    )
+
+    expect(result.imageUrl).toMatch(/^https:\/\/pub-test\.r2\.dev\/recipes\/[^/]/)
+    expect(result.imageUrl).not.toMatch(/\.dev\/\//)
+  })
+})

--- a/src/services/presign-service.ts
+++ b/src/services/presign-service.ts
@@ -1,0 +1,66 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { BadRequestError } from '../errors'
+import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE, buildImageKey } from '../lib/image-constraints'
+
+// Single-use in practice: each call mints a fresh, randomly-keyed object, so a
+// leaked URL only ever grants a PUT to that one key, not an update to an existing image.
+const PRESIGN_EXPIRY_SECONDS = 300
+
+export interface R2Credentials {
+  accountId: string
+  accessKeyId: string
+  secretAccessKey: string
+  publicUrl: string
+}
+
+export interface PresignedUpload {
+  uploadUrl: string
+  key: string
+  imageUrl: string
+}
+
+export async function createPresignedUpload(
+  credentials: R2Credentials,
+  bucketName: string,
+  contentType: string,
+  contentLength: number,
+): Promise<PresignedUpload> {
+  if (!ALLOWED_IMAGE_TYPES.has(contentType)) {
+    throw new BadRequestError('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif')
+  }
+  if (contentLength <= 0) {
+    throw new BadRequestError('contentLength must be greater than 0')
+  }
+  if (contentLength > MAX_IMAGE_SIZE) {
+    throw new BadRequestError('File exceeds 25MB limit')
+  }
+
+  const key = buildImageKey(contentType)
+
+  const client = new S3Client({
+    region: 'auto',
+    endpoint: `https://${credentials.accountId}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+    },
+  })
+
+  // ContentType is part of the signed request, so the client's PUT must send an
+  // identical Content-Type header or R2 will reject the upload with a signature
+  // mismatch. contentLength is intentionally NOT bound into the signature — S3-style
+  // presigned PUTs don't reliably enforce an exact body size, so it's only used above
+  // as an upfront sanity check, not a guarantee the uploaded object matches it.
+  const uploadUrl = await getSignedUrl(
+    client,
+    new PutObjectCommand({ Bucket: bucketName, Key: key, ContentType: contentType }),
+    { expiresIn: PRESIGN_EXPIRY_SECONDS },
+  )
+
+  return {
+    uploadUrl,
+    key,
+    imageUrl: `${credentials.publicUrl.replace(/\/$/, '')}/${key}`,
+  }
+}

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -13,4 +13,8 @@ interface CloudflareBindings {
   ADMIN_API_KEY: string
   IMAGE_BUCKET: R2Bucket
   R2_PUBLIC_URL: string
+  R2_BUCKET_NAME: string
+  R2_ACCOUNT_ID: string
+  R2_ACCESS_KEY_ID: string
+  R2_SECRET_ACCESS_KEY: string
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,7 +11,8 @@
     }
   ],
   "vars": {
-    "R2_PUBLIC_URL": "https://pub-017886dc539b41789e7c76de04239c5d.r2.dev"
+    "R2_PUBLIC_URL": "https://pub-017886dc539b41789e7c76de04239c5d.r2.dev",
+    "R2_BUCKET_NAME": "recipe-images"
   },
   // "kv_namespaces": [
   //   {


### PR DESCRIPTION
## What changed

Adds `POST /recipes/images/presign`, which returns a short-lived, single-use
presigned R2 PUT URL so clients upload image files directly to R2 instead of
routing the bytes through this API.

- `src/services/presign-service.ts` — validates content type/length and
  generates the presigned PUT URL via `@aws-sdk/client-s3` +
  `@aws-sdk/s3-request-presigner`, pointed at R2's S3-compatible endpoint.
- `src/lib/image-constraints.ts` — shared `MAX_IMAGE_SIZE` /
  `ALLOWED_IMAGE_TYPES` / `buildImageKey`, extracted out of the old
  `image-service.ts` so both the multipart and presign paths enforce the
  same rules.
- `src/lib/image-url.ts` — `recipes.imageUrl` is now stored as a bare R2 key
  (e.g. `recipes/<uuid>.jpg`) rather than a full URL, and resolved to a full
  public URL on every read (list, search, single, and POST/PATCH responses),
  so a future public-domain change (#41) never requires rewriting existing
  rows. Old rows that still hold a full URL are detected and left untouched.
- `src/routes/recipes.ts` strips a submitted `imageUrl`'s public-URL prefix
  before storing it, so clients can pass either the presign response's `key`
  or its `imageUrl` interchangeably.
- The old `POST /recipes/images` (server-mediated multipart upload) stays
  functional but is marked deprecated via `Deprecation`/`Link` response
  headers, until callers (e.g. foodies-finds) migrate.
- New env bindings: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
  `R2_SECRET_ACCESS_KEY` (secrets), `R2_BUCKET_NAME` (var). README updated
  with setup steps for scoping an R2 API token.

## Review notes

Reviewed by `api-reviewer` — no blocking issues. Should-fix items for the
human reviewer to weigh in on (none required pre-merge):

1. `recipeService` nested `steps[].imageUrl` isn't run through the new
   `withPublicImageUrl` resolver. There's no write path for step images
   today so it's unreachable, but if one lands later, `GET /recipes/:id`
   would return a raw key for step images instead of a full URL.
2. `if (input.imageUrl)` in `recipes.ts` (POST/PATCH) is a truthy check —
   an explicit empty-string `imageUrl` skips the key-stripping conversion
   and round-trips inconsistently (`''` in the DB, `null` on read). Safer
   as `typeof input.imageUrl === 'string'`.
3. `contentLength` is validated up front but not bound into the SigV4
   signature, so R2 won't reject an oversized PUT once the URL is issued —
   documented honestly in `presign-service.ts`, but a real gap if upload-size
   abuse becomes a concern. A presigned POST with a `content-length-range`
   policy condition would close it; worth a follow-up issue if this matters.
4. Route-level tests for bare-key URL resolution only cover the list
   endpoint; search, single-fetch, and POST/PATCH responses are exercised
   with full-URL fixtures, not the bare-key branch. The helper itself is
   unit-tested thoroughly in `image-url.test.ts`.

Closes #45