### PR TITLE
feat: adopt Hyperdrive for Postgres connections

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,1 +1,2 @@
-DATABASE_URL=postgresql://user:password@host/dbname
+DATABASE_URL=postgresql://user:password@host:5432/dbname
+CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE=postgresql://user:password@host:5432/dbname

--- a/README.md
+++ b/README.md
@@ -16,11 +16,34 @@ All variables are injected at runtime via Cloudflare secrets (production) or `.d
 
 | Variable        | Description                                          |
 | --------------- | ---------------------------------------------------- |
-| `DATABASE_URL`  | Postgres connection string (Supabase)                |
+| `DATABASE_URL`  | Postgres **direct** connection string (Supabase, port 5432) — used only by `drizzle-kit` migrations, which run outside the Worker and can't use the `HYPERDRIVE` binding |
 | `USER_API_KEY`  | API key for standard access (`X-Api-Key` header)     |
 | `ADMIN_API_KEY` | API key for admin routes (e.g. `DELETE /recipes/:id`) |
 
 `R2_PUBLIC_URL` and `IMAGE_BUCKET` are configured in `wrangler.jsonc` and do not need to be set as secrets.
+
+### Database connection (Hyperdrive)
+
+The Worker itself queries Postgres through a [Hyperdrive](https://developers.cloudflare.com/hyperdrive/)
+binding (`HYPERDRIVE`), not `DATABASE_URL` directly — Hyperdrive keeps a warm connection pool near
+Supabase so requests don't pay a full TCP+TLS+auth handshake on every invocation.
+
+Both `DATABASE_URL` and the Hyperdrive config must point at Supabase's **direct connection (port
+5432)**, not the Supavisor pooler (port 6543). Supavisor runs in transaction-pooling mode, which
+doesn't support prepared statements — routing Hyperdrive through it would reintroduce that
+constraint on top of Hyperdrive's own pooling. Supabase's direct connection defaults to IPv6; if
+Hyperdrive's egress can't reach it, Supabase's IPv4 add-on (Pro plan+) provides a static IPv4
+address for the direct connection.
+
+One-time setup (see also the Deployment section below):
+
+```bash
+pnpm exec wrangler hyperdrive create recipe-api-db \
+  --connection-string="postgresql://user:password@host:5432/dbname"
+```
+
+Copy the printed `id` into the `hyperdrive` binding's `id` field in `wrangler.jsonc`, replacing
+`<HYPERDRIVE_ID>`.
 
 ## Local development
 
@@ -29,6 +52,10 @@ pnpm install
 cp .dev.vars.example .dev.vars  # fill in values
 pnpm dev
 ```
+
+`.dev.vars` needs both `DATABASE_URL` (for `drizzle-kit`) and
+`CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE` (read by `wrangler dev` in place of the
+real Hyperdrive binding) pointed at Supabase's direct connection.
 
 ## Deployment
 
@@ -44,6 +71,8 @@ pnpm exec wrangler secret put ADMIN_API_KEY
 ```
 
 3. Verify the `recipe-images` R2 bucket exists in your Cloudflare account. If not: `pnpm exec wrangler r2 bucket create recipe-images`
+4. Create the Hyperdrive config (see [Database connection](#database-connection-hyperdrive) above)
+   and update the `id` in `wrangler.jsonc`'s `hyperdrive` binding.
 
 ### Deploy
 

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -3,6 +3,8 @@ import { drizzle } from 'drizzle-orm/postgres-js'
 import * as schema from './schema'
 
 export function createDb(connectionString: string) {
-  const client = postgres(connectionString)
+  // Workers allow at most 6 concurrent connections per invocation; stay under that
+  // even with Hyperdrive's own pooling in front of the connection.
+  const client = postgres(connectionString, { max: 5 })
   return drizzle(client, { schema })
 }

--- a/src/routes/cuisines.test.ts
+++ b/src/routes/cuisines.test.ts
@@ -10,7 +10,7 @@ vi.mock('../services/cuisine-service')
 type TestBindings = {
   USER_API_KEY: string
   ADMIN_API_KEY: string
-  DATABASE_URL: string
+  HYPERDRIVE: { connectionString: string }
 }
 
 const USER_KEY = 'test-user-key'
@@ -18,7 +18,7 @@ const ADMIN_KEY = 'test-admin-key'
 const TEST_ENV: TestBindings = {
   USER_API_KEY: USER_KEY,
   ADMIN_API_KEY: ADMIN_KEY,
-  DATABASE_URL: 'postgresql://test',
+  HYPERDRIVE: { connectionString: 'postgresql://test' },
 }
 
 const SAMPLE_CUISINES = [

--- a/src/routes/cuisines.ts
+++ b/src/routes/cuisines.ts
@@ -6,7 +6,7 @@ import { listCuisines, searchCuisines } from '../services/cuisine-service'
 export const cuisineRouter = new Hono<{ Bindings: CloudflareBindings }>()
 
 cuisineRouter.get('/', async (c) => {
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
   const query = c.req.query('query')
 
   if (!query || !query.trim()) {

--- a/src/routes/ingredients.test.ts
+++ b/src/routes/ingredients.test.ts
@@ -10,7 +10,7 @@ vi.mock('../services/ingredient-service')
 type TestBindings = {
   USER_API_KEY: string
   ADMIN_API_KEY: string
-  DATABASE_URL: string
+  HYPERDRIVE: { connectionString: string }
 }
 
 const USER_KEY = 'test-user-key'
@@ -18,7 +18,7 @@ const ADMIN_KEY = 'test-admin-key'
 const TEST_ENV: TestBindings = {
   USER_API_KEY: USER_KEY,
   ADMIN_API_KEY: ADMIN_KEY,
-  DATABASE_URL: 'postgresql://test',
+  HYPERDRIVE: { connectionString: 'postgresql://test' },
 }
 
 const SAMPLE_INGREDIENTS = [

--- a/src/routes/ingredients.ts
+++ b/src/routes/ingredients.ts
@@ -6,7 +6,7 @@ import { listIngredients, searchIngredients } from '../services/ingredient-servi
 export const ingredientRouter = new Hono<{ Bindings: CloudflareBindings }>()
 
 ingredientRouter.get('/', async (c) => {
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
   const query = c.req.query('query')
 
   if (!query || !query.trim()) {

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -12,7 +12,7 @@ vi.mock('../services/recipeService')
 type TestBindings = {
   USER_API_KEY: string
   ADMIN_API_KEY: string
-  DATABASE_URL: string
+  HYPERDRIVE: { connectionString: string }
 }
 
 const USER_KEY = 'test-user-key'
@@ -20,7 +20,7 @@ const ADMIN_KEY = 'test-admin-key'
 const TEST_ENV: TestBindings = {
   USER_API_KEY: USER_KEY,
   ADMIN_API_KEY: ADMIN_KEY,
-  DATABASE_URL: 'postgresql://test',
+  HYPERDRIVE: { connectionString: 'postgresql://test' },
 }
 
 const SAMPLE_LIST_ITEMS: recipeService.RecipeListItem[] = [

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -91,7 +91,7 @@ const RecipeUpdateSchema = z.object({
 })
 
 recipeRouter.get('/', async (c) => {
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
 
   const name = c.req.query('name')
   const tag = c.req.query('tag')
@@ -141,7 +141,7 @@ recipeRouter.get('/', async (c) => {
 })
 
 recipeRouter.post('/', requestLogger('recipe upload'), async (c) => {
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
   const body = await c.req.json()
   const input = RecipeSaveSchema.parse(body)
   const data = await createRecipe(db, input)
@@ -153,7 +153,7 @@ recipeRouter.post('/', requestLogger('recipe upload'), async (c) => {
 recipeRouter.get('/:id', async (c) => {
   const id = Number(c.req.param('id'))
   if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
   const data = await getRecipe(db, id)
   return c.json(buildSuccess(200, 'Recipe retrieved', data), 200)
 })
@@ -161,7 +161,7 @@ recipeRouter.get('/:id', async (c) => {
 recipeRouter.patch('/:id', requestLogger('recipe save'), async (c) => {
   const id = Number(c.req.param('id'))
   if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
   const body = await c.req.json()
   const input = RecipeUpdateSchema.parse(body)
   const data = await updateRecipe(db, id, input)
@@ -171,7 +171,7 @@ recipeRouter.patch('/:id', requestLogger('recipe save'), async (c) => {
 recipeRouter.delete('/:id', async (c) => {
   const id = Number(c.req.param('id'))
   if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
   await deleteRecipe(db, id)
   return c.body(null, 204)
 })

--- a/src/routes/tags.test.ts
+++ b/src/routes/tags.test.ts
@@ -10,7 +10,7 @@ vi.mock('../services/tag-service')
 type TestBindings = {
   USER_API_KEY: string
   ADMIN_API_KEY: string
-  DATABASE_URL: string
+  HYPERDRIVE: { connectionString: string }
 }
 
 const USER_KEY = 'test-user-key'
@@ -18,7 +18,7 @@ const ADMIN_KEY = 'test-admin-key'
 const TEST_ENV: TestBindings = {
   USER_API_KEY: USER_KEY,
   ADMIN_API_KEY: ADMIN_KEY,
-  DATABASE_URL: 'postgresql://test',
+  HYPERDRIVE: { connectionString: 'postgresql://test' },
 }
 
 const SAMPLE_TAGS = [

--- a/src/routes/tags.ts
+++ b/src/routes/tags.ts
@@ -6,7 +6,7 @@ import { listTags, searchTags } from '../services/tag-service'
 export const tagRouter = new Hono<{ Bindings: CloudflareBindings }>()
 
 tagRouter.get('/', async (c) => {
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
   const query = c.req.query('query')
 
   if (!query || !query.trim()) {

--- a/src/routes/units.test.ts
+++ b/src/routes/units.test.ts
@@ -10,7 +10,7 @@ vi.mock('../services/unit-service')
 type TestBindings = {
   USER_API_KEY: string
   ADMIN_API_KEY: string
-  DATABASE_URL: string
+  HYPERDRIVE: { connectionString: string }
 }
 
 const USER_KEY = 'test-user-key'
@@ -18,7 +18,7 @@ const ADMIN_KEY = 'test-admin-key'
 const TEST_ENV: TestBindings = {
   USER_API_KEY: USER_KEY,
   ADMIN_API_KEY: ADMIN_KEY,
-  DATABASE_URL: 'postgresql://test',
+  HYPERDRIVE: { connectionString: 'postgresql://test' },
 }
 
 const SAMPLE_UNITS = [

--- a/src/routes/units.ts
+++ b/src/routes/units.ts
@@ -6,7 +6,7 @@ import { listUnits } from '../services/unit-service'
 export const unitRouter = new Hono<{ Bindings: CloudflareBindings }>()
 
 unitRouter.get('/', async (c) => {
-  const db = createDb(c.env.DATABASE_URL)
+  const db = createDb(c.env.HYPERDRIVE.connectionString)
   const data = await listUnits(db)
   return c.json(buildSuccess(200, 'Units retrieved', data), 200)
 })

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -7,10 +7,20 @@ interface R2Bucket {
   delete(keys: string | string[]): Promise<void>
 }
 
+interface Hyperdrive {
+  readonly connectionString: string
+  readonly host: string
+  readonly port: number
+  readonly user: string
+  readonly password: string
+  readonly database: string
+}
+
 interface CloudflareBindings {
   DATABASE_URL: string
   USER_API_KEY: string
   ADMIN_API_KEY: string
   IMAGE_BUCKET: R2Bucket
   R2_PUBLIC_URL: string
+  HYPERDRIVE: Hyperdrive
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,9 +28,7 @@
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",
-      // TODO: replace with the id printed by `wrangler hyperdrive create`
-      // (see README's Hyperdrive setup section) before deploying this branch.
-      "id": "<HYPERDRIVE_ID>"
+      "id": "4465e315e0e242a3a438723c852943d1"
     }
   ],
   // "d1_databases": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -25,6 +25,14 @@
       "bucket_name": "recipe-images"
     }
   ],
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      // TODO: replace with the id printed by `wrangler hyperdrive create`
+      // (see README's Hyperdrive setup section) before deploying this branch.
+      "id": "<HYPERDRIVE_ID>"
+    }
+  ],
   // "d1_databases": [
   //   {
   //     "binding": "MY_DB",


### PR DESCRIPTION
## What changed

Migrates the Worker's Postgres connections from a raw `DATABASE_URL` env var
to a Cloudflare Hyperdrive binding (`HYPERDRIVE`), so requests reuse a warm
connection pool near Supabase instead of paying a full TCP+TLS+auth
handshake on every invocation.

- `wrangler.jsonc`: adds a `hyperdrive` binding pointed at a Hyperdrive
  config created against Supabase's **direct connection (port 5432)**, not
  the Supavisor pooler — Hyperdrive does its own pooling, so routing through
  another transaction-mode pooler would reintroduce the prepared-statement
  incompatibility this setup is meant to avoid.
- `worker-configuration.d.ts`: adds a `Hyperdrive` interface and `HYPERDRIVE`
  binding to `CloudflareBindings`.
- `src/db/client.ts`: caps the postgres.js client at `max: 5` connections —
  Workers allow at most 6 concurrent connections per invocation.
- All DB-touching routes (`cuisines`, `ingredients`, `tags`, `units`,
  `recipes`) and their tests now read `c.env.HYPERDRIVE.connectionString`
  instead of `c.env.DATABASE_URL`.
- `.dev.vars.example` / README: documents that `DATABASE_URL` stays around
  as a **direct-connection** var for `drizzle-kit` migrations (which run
  outside the Worker and can't use bindings), while the Worker itself uses
  the Hyperdrive binding; adds the local-dev override var
  (`CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE`) and a
  one-time `wrangler hyperdrive create` setup step.

Closes #44

## Review notes

Reviewed by api-reviewer — no blocking issues. The core Hyperdrive win
(every route goes through the `HYPERDRIVE` binding instead of dialing
Supabase directly, so requests get a warm pooled connection instead of a
fresh handshake) is intact and unaffected by anything below.

Should-fix, for follow-up (not addressed in this PR):

1. `worker-configuration.d.ts` still declares `DATABASE_URL` on
   `CloudflareBindings`, and the README's deploy steps still list
   `wrangler secret put DATABASE_URL`. Nothing in the deployed Worker reads
   it anymore (drizzle-kit uses `process.env.DATABASE_URL` locally/CI, never
   the Worker secret store) — worth dropping to avoid a future contributor
   reaching for the dead binding instead of `HYPERDRIVE`.

Notes (optional, not blocking):

- `src/db/client.ts` could pair `max: 5` with `fetch_types: false` to skip
  postgres-js's one-time `pg_type` round-trip on a fresh client (paid on
  every request here, since `createDb()` builds a new client per request).
  This is a minor trim on top of the connection Hyperdrive already keeps
  warm, not a gap in the pooling behavior itself — worth checking whether
  `src/db/schema` uses custom Postgres types before flipping it, since
  `fetch_types: false` disables their automatic deserialization.
- `pnpm run format:check` fails on 16 files repo-wide, including some
  touched here (`README.md`, `recipes.ts`, several route test files) — but
  this is pre-existing drift on `main`, not introduced by this PR.
- Recommend a manual `wrangler dev` smoke test against the real Hyperdrive
  local-proxy connection before merging — the unit tests all mock
  `createDb` and won't catch a misconfigured binding.

## Test plan

- [x] `pnpm test` — 140/140 passing
- [x] `pnpm run lint` — clean
- [ ] Manual `wrangler dev` verification against Hyperdrive's local
      connection string