### PR TITLE
fix: null, not undefined, on omitted nullable recipe fields

### DIFF
--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createRecipe, listRecipes, searchRecipes } from './recipeService'
-import { recipes } from '../db/schema'
+import { createRecipe, listRecipes, searchRecipes, updateRecipe } from './recipeService'
+import { recipeIngredients, recipeInstructionSteps, recipes } from '../db/schema'
 
 vi.mock('./cuisine-service', () => ({
   resolveCuisine: vi.fn().mockResolvedValue({ id: 1, name: 'Italian' }),
@@ -184,31 +184,52 @@ describe('listRecipes', () => {
   })
 })
 
-// The real postgres driver throws on `undefined` bind params (only `null` is a valid
-// SQL NULL), so the values passed to `.insert(recipes).values(...)` must never contain
-// undefined for an omitted optional field. A plain mock wouldn't reject on undefined the
-// way the driver does, so these tests assert on the captured values object directly.
-function makeCreateDb(recipeRow: { id: number; [key: string]: unknown }) {
-  const insertedRecipeValues: Record<string, unknown>[] = []
+// The real postgres driver throws on `undefined` bind params (only `null` is a valid SQL
+// NULL). rejectUndefined below simulates that so any insert/update `.values()`/`.set()`
+// call touching an omitted optional field fails the test the same way it would in
+// production, rather than silently passing like a plain mock would.
+function rejectUndefined(vals: Record<string, unknown>) {
+  for (const [key, value] of Object.entries(vals)) {
+    if (value === undefined) {
+      throw new Error(`Undefined values are not allowed (column "${key}")`)
+    }
+  }
+}
+
+function makeRecipeDb(finalRow: { id: number; [key: string]: unknown }) {
+  const insertedValues: { table: unknown; vals: Record<string, unknown> }[] = []
   const tx = {
     insert: vi.fn((table: unknown) => ({
       values: vi.fn((vals: Record<string, unknown>) => {
+        rejectUndefined(vals)
+        insertedValues.push({ table, vals })
         if (table === recipes) {
-          insertedRecipeValues.push(vals)
-          return { returning: vi.fn().mockResolvedValue([{ id: recipeRow.id }]) }
+          return { returning: vi.fn().mockResolvedValue([{ id: finalRow.id }]) }
         }
         return Promise.resolve(undefined)
       }),
     })),
+    update: vi.fn(() => ({
+      set: vi.fn((vals: Record<string, unknown>) => {
+        rejectUndefined(vals)
+        return { where: vi.fn().mockResolvedValue(undefined) }
+      }),
+    })),
+    delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    query: { recipes: { findFirst: vi.fn().mockResolvedValue(finalRow) } },
   }
   const db = {
     transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) => cb(tx)),
-    query: { recipes: { findFirst: vi.fn().mockResolvedValue(recipeRow) } },
-  } as unknown as Parameters<typeof createRecipe>[0]
-  return { db, insertedRecipeValues }
+    query: { recipes: { findFirst: vi.fn().mockResolvedValue(finalRow) } },
+  } as unknown as Parameters<typeof createRecipe>[0] & Parameters<typeof updateRecipe>[1]
+  return { db, insertedValues }
 }
 
-const CREATE_RECIPE_ROW = {
+function valuesFor(insertedValues: { table: unknown; vals: Record<string, unknown> }[], table: unknown) {
+  return insertedValues.filter((v) => v.table === table).map((v) => v.vals)
+}
+
+const RECIPE_ROW = {
   id: 1,
   name: 'Pasta',
   description: '',
@@ -240,16 +261,41 @@ const CREATE_RECIPE_INPUT: Parameters<typeof createRecipe>[1] = {
 
 describe('createRecipe', () => {
   it('inserts null, not undefined, when calories and imageUrl are omitted', async () => {
-    const { db, insertedRecipeValues } = makeCreateDb(CREATE_RECIPE_ROW)
+    const { db, insertedValues } = makeRecipeDb(RECIPE_ROW)
     await createRecipe(db, CREATE_RECIPE_INPUT)
-    expect(insertedRecipeValues[0].calories).toBeNull()
-    expect(insertedRecipeValues[0].imageUrl).toBeNull()
+    const [recipeValues] = valuesFor(insertedValues, recipes)
+    expect(recipeValues.calories).toBeNull()
+    expect(recipeValues.imageUrl).toBeNull()
   })
 
   it('passes explicit calories and imageUrl through unchanged', async () => {
-    const { db, insertedRecipeValues } = makeCreateDb(CREATE_RECIPE_ROW)
+    const { db, insertedValues } = makeRecipeDb(RECIPE_ROW)
     await createRecipe(db, { ...CREATE_RECIPE_INPUT, calories: 450, imageUrl: 'recipes/1.jpg' })
-    expect(insertedRecipeValues[0].calories).toBe(450)
-    expect(insertedRecipeValues[0].imageUrl).toBe('recipes/1.jpg')
+    const [recipeValues] = valuesFor(insertedValues, recipes)
+    expect(recipeValues.calories).toBe(450)
+    expect(recipeValues.imageUrl).toBe('recipes/1.jpg')
+  })
+
+  it('inserts null, not undefined, when ingredient notes and step tip are omitted', async () => {
+    const { db, insertedValues } = makeRecipeDb(RECIPE_ROW)
+    await createRecipe(db, CREATE_RECIPE_INPUT)
+    const [ingredientValues] = valuesFor(insertedValues, recipeIngredients)
+    const [stepValues] = valuesFor(insertedValues, recipeInstructionSteps)
+    expect(ingredientValues.notes).toBeNull()
+    expect(stepValues.tip).toBeNull()
+  })
+})
+
+describe('updateRecipe', () => {
+  it('inserts null, not undefined, when ingredient notes and step tip are omitted', async () => {
+    const { db, insertedValues } = makeRecipeDb(RECIPE_ROW)
+    await updateRecipe(db, 1, {
+      ingredients: [{ name: 'Spaghetti', unitId: 1, quantity: 200 }],
+      steps: [{ stepNumber: 1, description: 'Boil water' }],
+    })
+    const [ingredientValues] = valuesFor(insertedValues, recipeIngredients)
+    const [stepValues] = valuesFor(insertedValues, recipeInstructionSteps)
+    expect(ingredientValues.notes).toBeNull()
+    expect(stepValues.tip).toBeNull()
   })
 })

--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it, vi } from 'vitest'
-import { listRecipes, searchRecipes } from './recipeService'
+import { createRecipe, listRecipes, searchRecipes } from './recipeService'
+import { recipes } from '../db/schema'
+
+vi.mock('./cuisine-service', () => ({
+  resolveCuisine: vi.fn().mockResolvedValue({ id: 1, name: 'Italian' }),
+}))
+vi.mock('./ingredient-service', () => ({
+  resolveIngredient: vi.fn().mockResolvedValue({ id: 10, name: 'Spaghetti' }),
+}))
+vi.mock('./unit-service', () => ({
+  resolveUnit: vi.fn().mockResolvedValue({ id: 1, name: 'Gram', abbreviation: 'g' }),
+}))
+vi.mock('./tag-service', () => ({
+  resolveTag: vi.fn().mockResolvedValue({ id: 5, name: 'Quick' }),
+}))
 
 function makeDb(rows: { id: number; name: string; imageUrl: string | null }[]) {
   const chain = {
@@ -167,5 +181,75 @@ describe('listRecipes', () => {
     await listRecipes(db, 2, 999)
     expect(chain.limit).toHaveBeenCalledWith(100)
     expect(chain.offset).toHaveBeenCalledWith(200)
+  })
+})
+
+// The real postgres driver throws on `undefined` bind params (only `null` is a valid
+// SQL NULL), so the values passed to `.insert(recipes).values(...)` must never contain
+// undefined for an omitted optional field. A plain mock wouldn't reject on undefined the
+// way the driver does, so these tests assert on the captured values object directly.
+function makeCreateDb(recipeRow: { id: number; [key: string]: unknown }) {
+  const insertedRecipeValues: Record<string, unknown>[] = []
+  const tx = {
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn((vals: Record<string, unknown>) => {
+        if (table === recipes) {
+          insertedRecipeValues.push(vals)
+          return { returning: vi.fn().mockResolvedValue([{ id: recipeRow.id }]) }
+        }
+        return Promise.resolve(undefined)
+      }),
+    })),
+  }
+  const db = {
+    transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) => cb(tx)),
+    query: { recipes: { findFirst: vi.fn().mockResolvedValue(recipeRow) } },
+  } as unknown as Parameters<typeof createRecipe>[0]
+  return { db, insertedRecipeValues }
+}
+
+const CREATE_RECIPE_ROW = {
+  id: 1,
+  name: 'Pasta',
+  description: '',
+  author: '',
+  calories: null,
+  servings: 2,
+  cookingTime: 10,
+  preparationTime: 5,
+  imageUrl: null,
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  updatedAt: new Date('2024-01-01T00:00:00Z'),
+  cuisine: { id: 1, name: 'Italian' },
+  ingredients: [],
+  tags: [],
+  steps: [],
+}
+
+const CREATE_RECIPE_INPUT: Parameters<typeof createRecipe>[1] = {
+  name: 'Pasta',
+  description: '',
+  servings: 2,
+  cookingTime: 10,
+  preparationTime: 5,
+  cuisine: { name: 'Italian' },
+  ingredients: [{ name: 'Spaghetti', unitId: 1, quantity: 200 }],
+  steps: [{ stepNumber: 1, description: 'Boil water' }],
+  author: '',
+}
+
+describe('createRecipe', () => {
+  it('inserts null, not undefined, when calories and imageUrl are omitted', async () => {
+    const { db, insertedRecipeValues } = makeCreateDb(CREATE_RECIPE_ROW)
+    await createRecipe(db, CREATE_RECIPE_INPUT)
+    expect(insertedRecipeValues[0].calories).toBeNull()
+    expect(insertedRecipeValues[0].imageUrl).toBeNull()
+  })
+
+  it('passes explicit calories and imageUrl through unchanged', async () => {
+    const { db, insertedRecipeValues } = makeCreateDb(CREATE_RECIPE_ROW)
+    await createRecipe(db, { ...CREATE_RECIPE_INPUT, calories: 450, imageUrl: 'recipes/1.jpg' })
+    expect(insertedRecipeValues[0].calories).toBe(450)
+    expect(insertedRecipeValues[0].imageUrl).toBe('recipes/1.jpg')
   })
 })

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -280,8 +280,10 @@ export async function createRecipe(db: Db, input: RecipeSaveInput): Promise<Reci
         description: input.description,
         cuisineId: cuisine.id,
         author: input.author,
-        // ?? null: the postgres driver rejects `undefined` bind params outright,
-        // so an omitted (as opposed to explicit null) field must be coerced.
+        // ?? null on every nullable optional field below: the postgres driver rejects
+        // `undefined` bind params outright, so an omitted field must be coerced. Applies
+        // wherever an insert takes a nullable-no-default column straight from input
+        // (see also notes/tip in the ingredient/step inserts further down).
         calories: input.calories ?? null,
         servings: input.servings,
         cookingTime: input.cookingTime,
@@ -302,7 +304,7 @@ export async function createRecipe(db: Db, input: RecipeSaveInput): Promise<Reci
         ingredientId: ingredient.id,
         unitId: unit.id,
         quantity: String(ing.quantity),
-        notes: ing.notes,
+        notes: ing.notes ?? null,
       })
     }
 
@@ -315,7 +317,7 @@ export async function createRecipe(db: Db, input: RecipeSaveInput): Promise<Reci
         recipeId: recipe.id,
         stepNumber: step.stepNumber,
         description: step.description,
-        tip: step.tip,
+        tip: step.tip ?? null,
       })
     }
 
@@ -370,7 +372,7 @@ export async function updateRecipe(
           ingredientId: ingredient.id,
           unitId: unit.id,
           quantity: String(ing.quantity),
-          notes: ing.notes,
+          notes: ing.notes ?? null,
         })
       }
     }
@@ -390,7 +392,7 @@ export async function updateRecipe(
           recipeId: id,
           stepNumber: step.stepNumber,
           description: step.description,
-          tip: step.tip,
+          tip: step.tip ?? null,
         })
       }
     }

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -280,11 +280,13 @@ export async function createRecipe(db: Db, input: RecipeSaveInput): Promise<Reci
         description: input.description,
         cuisineId: cuisine.id,
         author: input.author,
-        calories: input.calories,
+        // ?? null: the postgres driver rejects `undefined` bind params outright,
+        // so an omitted (as opposed to explicit null) field must be coerced.
+        calories: input.calories ?? null,
         servings: input.servings,
         cookingTime: input.cookingTime,
         preparationTime: input.preparationTime,
-        imageUrl: input.imageUrl,
+        imageUrl: input.imageUrl ?? null,
         createdAt: now,
         updatedAt: now,
       })


### PR DESCRIPTION
## What changed and why

POST /recipes returns a 500 when `calories` is omitted from the
request body, instead of inserting NULL. Root cause: `createRecipe`
always set `calories: input.calories` (and similarly `imageUrl`,
`notes`, `tip`) directly from the parsed input. When a field is
omitted, that value is `undefined` — not `null`. Drizzle passes every
present key through as a bind parameter regardless of value, and the
`postgres` driver rejects `undefined` params outright
(`UNDEFINED_VALUE: Undefined values are not allowed`; only `null` is
a valid SQL NULL). That throw wasn't caught, so it surfaced as an
uncaught 500.

This affected every nullable, no-default column fed straight from
input on insert:

- `recipes.calories`, `recipes.imageUrl` — `createRecipe`
- `recipe_ingredients.notes` — `createRecipe` and `updateRecipe`
  (when `ingredients` is replaced)
- `recipe_instruction_steps.tip` — `createRecipe` and `updateRecipe`
  (when `steps` is replaced)

Fix: coerce each with `?? null` before it reaches `.values()`, so an
omitted field becomes an explicit NULL rather than an invalid
`undefined` bind param. `updateRecipe`'s top-level `patch` object was
already safe — it only sets a key when `input.x !== undefined` — so
no change was needed there.

## Tests

`src/services/recipeService.test.ts` now has a shared `makeRecipeDb`
test harness for `createRecipe`/`updateRecipe` with a `rejectUndefined`
check on every `.insert(...).values()` / `.update(...).set()` call,
simulating the real driver's behavior. New tests cover:

- `calories`/`imageUrl` omitted on create → inserted as `null`
- `calories`/`imageUrl` explicit → passed through unchanged
- ingredient `notes` / step `tip` omitted, on both create and update
  → inserted as `null`

Confirmed these tests actually catch the regression: reverting the
service fix locally makes them fail with the same `Undefined values
are not allowed` error the real driver throws, rather than passing
vacuously.

## Review notes

Reviewed via the `api-reviewer` subagent, two passes:

- First pass caught that the initial fix only covered
  `calories`/`imageUrl` and missed the identical bug in the
  ingredient/step inserts — fixed in a follow-up commit.
- Second pass: no blocking issues. One non-blocking nit: the
  explanatory comment on the driver's undefined-vs-null behavior
  lives once near the `calories`/`imageUrl` assignment; a reader
  jumping straight into `updateRecipe`'s ingredient/step inserts
  won't see it. Left as-is per reviewer (nit, not blocking) — happy
  to add short pointer comments at those sites if preferred.

Closes #52