### PR TITLE
chore: fix repo-wide formatting drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Requests are rate limited to **60 per minute per API key**. Exceeding the limit 
 
 All variables are injected at runtime via Cloudflare secrets (production) or `.dev.vars` (local).
 
-| Variable                | Description                                                     |
-| ----------------------- | ---------------------------------------------------------------- |
-| `DATABASE_URL`          | Postgres **direct** connection string (Supabase, port 5432) — used only by `drizzle-kit` migrations, which run outside the Worker and can't use the `HYPERDRIVE` binding |
-| `USER_API_KEY`          | API key for standard access (`X-Api-Key` header)                 |
-| `ADMIN_API_KEY`         | API key for admin routes (e.g. `DELETE /recipes/:id`)            |
-| `R2_ACCOUNT_ID`         | Cloudflare account ID — used to build the R2 S3-compatible endpoint |
-| `R2_ACCESS_KEY_ID`      | R2 API token access key ID, scoped to the `recipe-images` bucket |
-| `R2_SECRET_ACCESS_KEY`  | R2 API token secret access key                                   |
+| Variable               | Description                                                                                                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `DATABASE_URL`         | Postgres **direct** connection string (Supabase, port 5432) — used only by `drizzle-kit` migrations, which run outside the Worker and can't use the `HYPERDRIVE` binding |
+| `USER_API_KEY`         | API key for standard access (`X-Api-Key` header)                                                                                                                         |
+| `ADMIN_API_KEY`        | API key for admin routes (e.g. `DELETE /recipes/:id`)                                                                                                                    |
+| `R2_ACCOUNT_ID`        | Cloudflare account ID — used to build the R2 S3-compatible endpoint                                                                                                      |
+| `R2_ACCESS_KEY_ID`     | R2 API token access key ID, scoped to the `recipe-images` bucket                                                                                                         |
+| `R2_SECRET_ACCESS_KEY` | R2 API token secret access key                                                                                                                                           |
 
 `R2_PUBLIC_URL`, `R2_BUCKET_NAME`, and `IMAGE_BUCKET` are configured in `wrangler.jsonc` and do not
 need to be set as secrets.
@@ -63,8 +63,7 @@ The Worker itself queries Postgres through a [Hyperdrive](https://developers.clo
 binding (`HYPERDRIVE`), not `DATABASE_URL` directly — Hyperdrive keeps a warm connection pool near
 Supabase so requests don't pay a full TCP+TLS+auth handshake on every invocation.
 
-Both `DATABASE_URL` and the Hyperdrive config must point at Supabase's **direct connection (port
-5432)**, not the Supavisor pooler (port 6543). Supavisor runs in transaction-pooling mode, which
+Both `DATABASE_URL` and the Hyperdrive config must point at Supabase's **direct connection (port 5432)**, not the Supavisor pooler (port 6543). Supavisor runs in transaction-pooling mode, which
 doesn't support prepared statements — routing Hyperdrive through it would reintroduce that
 constraint on top of Hyperdrive's own pooling. Supabase's direct connection defaults to IPv6; if
 Hyperdrive's egress can't reach it, Supabase's IPv4 add-on (Pro plan+) provides a static IPv4

--- a/src/db/schema/recipe-ingredients.ts
+++ b/src/db/schema/recipe-ingredients.ts
@@ -10,9 +10,15 @@ export const recipeIngredients = recipeservice.table(
   'recipe_ingredients',
   {
     id: bigserial('recipe_ingredient_id', { mode: 'number' }).primaryKey(),
-    recipeId: bigint('recipe_id', { mode: 'number' }).notNull().references(() => recipes.id, { onDelete: 'cascade' }),
-    ingredientId: bigint('ingredient_id', { mode: 'number' }).notNull().references(() => ingredients.id),
-    unitId: bigint('unit_id', { mode: 'number' }).notNull().references(() => units.id),
+    recipeId: bigint('recipe_id', { mode: 'number' })
+      .notNull()
+      .references(() => recipes.id, { onDelete: 'cascade' }),
+    ingredientId: bigint('ingredient_id', { mode: 'number' })
+      .notNull()
+      .references(() => ingredients.id),
+    unitId: bigint('unit_id', { mode: 'number' })
+      .notNull()
+      .references(() => units.id),
     quantity: numeric('quantity', { precision: 8, scale: 2 }).notNull(),
     notes: varchar('notes', { length: 255 }),
   },

--- a/src/db/schema/recipe-instruction-steps.ts
+++ b/src/db/schema/recipe-instruction-steps.ts
@@ -8,7 +8,9 @@ export const recipeInstructionSteps = recipeservice.table(
   'recipe_instruction_steps',
   {
     id: bigserial('step_id', { mode: 'number' }).primaryKey(),
-    recipeId: bigint('recipe_id', { mode: 'number' }).notNull().references(() => recipes.id, { onDelete: 'cascade' }),
+    recipeId: bigint('recipe_id', { mode: 'number' })
+      .notNull()
+      .references(() => recipes.id, { onDelete: 'cascade' }),
     stepNumber: smallint('step_number').notNull(),
     description: text('description').notNull(),
     imageUrl: varchar('image_url', { length: 255 }),

--- a/src/db/schema/recipe-tags.ts
+++ b/src/db/schema/recipe-tags.ts
@@ -9,8 +9,12 @@ export const recipeTags = recipeservice.table(
   'recipe_tags',
   {
     id: bigserial('recipe_tag_id', { mode: 'number' }).primaryKey(),
-    recipeId: bigint('recipe_id', { mode: 'number' }).notNull().references(() => recipes.id, { onDelete: 'cascade' }),
-    tagId: bigint('tag_id', { mode: 'number' }).notNull().references(() => tags.id),
+    recipeId: bigint('recipe_id', { mode: 'number' })
+      .notNull()
+      .references(() => recipes.id, { onDelete: 'cascade' }),
+    tagId: bigint('tag_id', { mode: 'number' })
+      .notNull()
+      .references(() => tags.id),
   },
   (t) => [unique().on(t.recipeId, t.tagId)],
 )

--- a/src/db/schema/recipes.ts
+++ b/src/db/schema/recipes.ts
@@ -11,7 +11,9 @@ export const recipes = recipeservice.table('recipes', {
   id: bigserial('id', { mode: 'number' }).primaryKey(),
   name: varchar('recipe_name', { length: 255 }).notNull(),
   description: text('description').notNull(),
-  cuisineId: smallint('cuisine_id').notNull().references(() => cuisines.id),
+  cuisineId: smallint('cuisine_id')
+    .notNull()
+    .references(() => cuisines.id),
   author: varchar('author', { length: 255 }).notNull(),
   // Nullable intentionally: DB column is nullable despite Java entity using a primitive short.
   // The issue spec and actual DB state take precedence over the Java source here.

--- a/src/lib/image-url.test.ts
+++ b/src/lib/image-url.test.ts
@@ -32,9 +32,7 @@ describe('toPublicUrl', () => {
   })
 
   it('prefixes a bare key with the public URL', () => {
-    expect(toPublicUrl('recipes/abc-123.jpg', PUBLIC_URL)).toBe(
-      `${PUBLIC_URL}/recipes/abc-123.jpg`,
-    )
+    expect(toPublicUrl('recipes/abc-123.jpg', PUBLIC_URL)).toBe(`${PUBLIC_URL}/recipes/abc-123.jpg`)
   })
 
   it('strips a trailing slash from publicUrl before prefixing', () => {

--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -44,7 +44,7 @@ describe('authMiddleware', () => {
 
     it('returns the standard error envelope', async () => {
       const res = await request('GET', '/recipes')
-      const body = await res.json() as Record<string, any>
+      const body = (await res.json()) as Record<string, any>
       expect(body.status).toBe(401)
       expect(body.message).toBe('Invalid or missing API key')
       expect(body.path).toBe('/recipes')
@@ -104,7 +104,7 @@ describe('authMiddleware', () => {
 
     it('returns the standard error envelope when rejecting user key', async () => {
       const res = await request('DELETE', '/recipes/123', USER_KEY)
-      const body = await res.json() as Record<string, any>
+      const body = (await res.json()) as Record<string, any>
       expect(body.status).toBe(401)
       expect(body.message).toBe('Invalid or missing API key')
       expect(body.path).toBe('/recipes/123')

--- a/src/middleware/rate-limiter.test.ts
+++ b/src/middleware/rate-limiter.test.ts
@@ -52,7 +52,7 @@ describe('rateLimiterMiddleware', () => {
       await request(app, USER_KEY)
     }
     const res = await request(app, USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.status).toBe(429)
     expect(body.message).toBe('Rate limit exceeded')
     expect(body.path).toBe('/recipes')

--- a/src/routes/cuisines.test.ts
+++ b/src/routes/cuisines.test.ts
@@ -54,7 +54,7 @@ describe('GET /cuisines', () => {
   it('returns 200 with all cuisines when no query param', async () => {
     const res = await request('/cuisines', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Cuisines retrieved')
     expect(body.data).toEqual(SAMPLE_CUISINES)
@@ -64,7 +64,7 @@ describe('GET /cuisines', () => {
   it('returns all cuisines for empty query string', async () => {
     const res = await request('/cuisines?query=', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Cuisines retrieved')
     expect(vi.mocked(cuisineService.listCuisines)).toHaveBeenCalledOnce()
     expect(vi.mocked(cuisineService.searchCuisines)).not.toHaveBeenCalled()
@@ -73,7 +73,7 @@ describe('GET /cuisines', () => {
   it('returns all cuisines for whitespace-only query', async () => {
     const res = await request('/cuisines?query=   ', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Cuisines retrieved')
     expect(vi.mocked(cuisineService.listCuisines)).toHaveBeenCalledOnce()
     expect(vi.mocked(cuisineService.searchCuisines)).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('GET /cuisines', () => {
     vi.mocked(cuisineService.searchCuisines).mockResolvedValue([{ id: 1, name: 'Italian' }])
     const res = await request('/cuisines?query=ital', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Cuisines queried')
     expect(body.data).toEqual([{ id: 1, name: 'Italian' }])
     expect(vi.mocked(cuisineService.searchCuisines)).toHaveBeenCalledWith(expect.anything(), 'ital')
@@ -94,7 +94,7 @@ describe('GET /cuisines', () => {
     vi.mocked(cuisineService.searchCuisines).mockResolvedValue([])
     const res = await request('/cuisines?query=zzz', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Cuisines queried')
     expect(body.data).toEqual([])
   })

--- a/src/routes/images.test.ts
+++ b/src/routes/images.test.ts
@@ -78,12 +78,7 @@ function makeFormData(file: File | null) {
   return form
 }
 
-function makeFile(
-  content = 'fake image',
-  name = 'photo.jpg',
-  type = 'image/jpeg',
-  size?: number,
-) {
+function makeFile(content = 'fake image', name = 'photo.jpg', type = 'image/jpeg', size?: number) {
   if (size !== undefined) {
     return new File([new Uint8Array(size)], name, { type })
   }
@@ -99,7 +94,7 @@ describe('POST /recipes/images', () => {
     vi.mocked(imageService.uploadImage).mockResolvedValue(UPLOADED_URL)
 
     const res = await uploadRequest(makeFormData(makeFile()), USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
 
     expect(res.status).toBe(200)
     expect(body.message).toBe('Image uploaded')
@@ -117,7 +112,7 @@ describe('POST /recipes/images', () => {
 
   it('returns 400 when file field is missing from form', async () => {
     const res = await uploadRequest(makeFormData(null), USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('File must not be empty')
@@ -130,7 +125,7 @@ describe('POST /recipes/images', () => {
     )
 
     const res = await uploadRequest(makeFormData(makeFile()), USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('File exceeds 25MB limit')
@@ -142,7 +137,7 @@ describe('POST /recipes/images', () => {
     )
 
     const res = await uploadRequest(makeFormData(makeFile('')), USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('File must not be empty')
@@ -153,8 +148,11 @@ describe('POST /recipes/images', () => {
       new BadRequestError('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif'),
     )
 
-    const res = await uploadRequest(makeFormData(makeFile('pdf', 'doc.pdf', 'application/pdf')), USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const res = await uploadRequest(
+      makeFormData(makeFile('pdf', 'doc.pdf', 'application/pdf')),
+      USER_KEY,
+    )
+    const body = (await res.json()) as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('Unsupported file type. Allowed: jpeg, png, webp, gif, heic, heif')
@@ -181,19 +179,17 @@ describe('DELETE /recipes/images', () => {
     )
 
     const res = await deleteRequest('', USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('Image key must not be empty')
   })
 
   it('returns 400 when key does not start with recipes/', async () => {
-    vi.mocked(imageService.deleteImage).mockRejectedValue(
-      new BadRequestError('Invalid image key'),
-    )
+    vi.mocked(imageService.deleteImage).mockRejectedValue(new BadRequestError('Invalid image key'))
 
     const res = await deleteRequest('other/abc-123.jpg', USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
 
     expect(res.status).toBe(400)
     expect(body.message).toBe('Invalid image key')

--- a/src/routes/ingredients.test.ts
+++ b/src/routes/ingredients.test.ts
@@ -54,7 +54,7 @@ describe('GET /ingredients', () => {
   it('returns 200 with all ingredients when no query param', async () => {
     const res = await request('/ingredients', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Ingredients retrieved')
     expect(body.data).toEqual(SAMPLE_INGREDIENTS)
@@ -64,7 +64,7 @@ describe('GET /ingredients', () => {
   it('returns all ingredients for empty query string', async () => {
     const res = await request('/ingredients?query=', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Ingredients retrieved')
     expect(vi.mocked(ingredientService.listIngredients)).toHaveBeenCalledOnce()
     expect(vi.mocked(ingredientService.searchIngredients)).not.toHaveBeenCalled()
@@ -73,7 +73,7 @@ describe('GET /ingredients', () => {
   it('returns all ingredients for whitespace-only query', async () => {
     const res = await request('/ingredients?query=   ', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Ingredients retrieved')
     expect(vi.mocked(ingredientService.listIngredients)).toHaveBeenCalledOnce()
     expect(vi.mocked(ingredientService.searchIngredients)).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('GET /ingredients', () => {
     vi.mocked(ingredientService.searchIngredients).mockResolvedValue([{ id: 1, name: 'Garlic' }])
     const res = await request('/ingredients?query=gar', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Ingredients queried')
     expect(body.data).toEqual([{ id: 1, name: 'Garlic' }])
     expect(vi.mocked(ingredientService.searchIngredients)).toHaveBeenCalledWith(
@@ -97,7 +97,7 @@ describe('GET /ingredients', () => {
     vi.mocked(ingredientService.searchIngredients).mockResolvedValue([])
     const res = await request('/ingredients?query=zzz', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Ingredients queried')
     expect(body.data).toEqual([])
   })

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -109,7 +109,7 @@ describe('GET /recipes', () => {
   it('returns 200 with paginated slim list', async () => {
     const res = await request('/recipes')
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Recipes retrieved')
     expect(body.data).toEqual(SAMPLE_LIST_ITEMS)
@@ -121,7 +121,7 @@ describe('GET /recipes', () => {
       { id: 3, name: 'Tacos', imageUrl: 'recipes/xyz-789.jpg' },
     ])
     const res = await request('/recipes')
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.data[0].imageUrl).toBe(`${TEST_ENV.R2_PUBLIC_URL}/recipes/xyz-789.jpg`)
   })
 
@@ -164,7 +164,7 @@ describe('GET /recipes', () => {
   it('routes to searchRecipes when filter params are present', async () => {
     const res = await request('/recipes?name=pasta&cuisineId=1')
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Recipes queried')
     expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
       expect.anything(),
@@ -186,7 +186,7 @@ describe('GET /recipes', () => {
     it('filters by name', async () => {
       const res = await request('/recipes?name=pasta')
       expect(res.status).toBe(200)
-      const body = await res.json() as Record<string, any>
+      const body = (await res.json()) as Record<string, any>
       expect(body.message).toBe('Recipes queried')
       expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
         expect.anything(),
@@ -261,7 +261,7 @@ describe('GET /recipes', () => {
     it('blank ?name= still triggers search mode (service is responsible for ignoring it)', async () => {
       const res = await request('/recipes?name=')
       expect(res.status).toBe(200)
-      const body = await res.json() as Record<string, any>
+      const body = (await res.json()) as Record<string, any>
       expect(body.message).toBe('Recipes queried')
       expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
         expect.anything(),
@@ -273,7 +273,7 @@ describe('GET /recipes', () => {
     it('whitespace-only ?name= still triggers search mode', async () => {
       const res = await request('/recipes?name=%20%20%20')
       expect(res.status).toBe(200)
-      const body = await res.json() as Record<string, any>
+      const body = (await res.json()) as Record<string, any>
       expect(body.message).toBe('Recipes queried')
       expect(vi.mocked(recipeService.searchRecipes)).toHaveBeenCalledWith(
         expect.anything(),
@@ -284,7 +284,7 @@ describe('GET /recipes', () => {
 
     it('returns slim { id, name, imageUrl } DTO shape', async () => {
       const res = await request('/recipes?name=pasta')
-      const body = await res.json() as Record<string, any>
+      const body = (await res.json()) as Record<string, any>
       expect(body.data).toEqual(SAMPLE_LIST_ITEMS)
       expect(body.data[0]).toMatchObject({ id: expect.any(Number), name: expect.any(String) })
       expect(body.data[0]).toHaveProperty('imageUrl')
@@ -305,7 +305,7 @@ describe('POST /recipes', () => {
     const res = await request('/recipes', { method: 'POST', body: SAVE_BODY })
     expect(res.status).toBe(201)
     expect(res.headers.get('Location')).toBe('/recipes/1')
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.status).toBe(201)
     expect(body.message).toBe('Recipe saved')
     expect(body.data.id).toBe(1)
@@ -344,7 +344,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, name: 'A' },
     })
     expect(res.status).toBe(400)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Recipe name must be between 2 to 150 characters.')
   })
 
@@ -354,7 +354,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, servings: 0 },
     })
     expect(res.status).toBe(400)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Servings must be a more than zero.')
   })
 
@@ -364,7 +364,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, cookingTime: -1 },
     })
     expect(res.status).toBe(400)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Cooking time cannot be negative.')
   })
 
@@ -374,7 +374,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, preparationTime: 0 },
     })
     expect(res.status).toBe(400)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Preparation time cannot be zero minutes.')
   })
 
@@ -384,7 +384,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, ingredients: [] },
     })
     expect(res.status).toBe(400)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('There must be at least one ingredient.')
   })
 
@@ -394,7 +394,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, steps: [] },
     })
     expect(res.status).toBe(400)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('There must be at least one step.')
   })
 
@@ -422,7 +422,7 @@ describe('POST /recipes', () => {
       body: { ...SAVE_BODY, cuisine: {} },
     })
     expect(res.status).toBe(400)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Cuisine request must have either an ID or a name.')
   })
 
@@ -432,7 +432,7 @@ describe('POST /recipes', () => {
     )
     const res = await request('/recipes', { method: 'POST', body: SAVE_BODY })
     expect(res.status).toBe(404)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Unit ID not found: 999')
   })
 })
@@ -444,7 +444,7 @@ describe('GET /recipes/:id', () => {
     vi.mocked(recipeService.getRecipe).mockResolvedValue(FULL_RECIPE)
     const res = await request('/recipes/1')
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Recipe retrieved')
     expect(body.data.id).toBe(1)
@@ -459,7 +459,7 @@ describe('GET /recipes/:id', () => {
     )
     const res = await request('/recipes/999')
     expect(res.status).toBe(404)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Recipe not found with id: 999')
   })
 
@@ -478,7 +478,7 @@ describe('PATCH /recipes/:id', () => {
     vi.mocked(recipeService.updateRecipe).mockResolvedValue(updated)
     const res = await request('/recipes/1', { method: 'PATCH', body: { name: 'Updated Pasta' } })
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Recipe updated')
     expect(body.data.name).toBe('Updated Pasta')
   })
@@ -583,7 +583,7 @@ describe('DELETE /recipes/:id', () => {
     )
     const res = await request('/recipes/999', { method: 'DELETE', apiKey: ADMIN_KEY })
     expect(res.status).toBe(404)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Recipe not found with id: 999')
   })
 

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -128,7 +128,15 @@ recipeRouter.get('/', async (c) => {
     ingredientId !== undefined
 
   if (hasFilter) {
-    const data = await searchRecipes(db, { name, tag, cuisine, ingredient, tagId, cuisineId, ingredientId })
+    const data = await searchRecipes(db, {
+      name,
+      tag,
+      cuisine,
+      ingredient,
+      tagId,
+      cuisineId,
+      ingredientId,
+    })
     return c.json(
       buildSuccess(
         200,
@@ -161,9 +169,13 @@ recipeRouter.post('/', requestLogger('recipe upload'), async (c) => {
   const input = RecipeSaveSchema.parse(body)
   if (input.imageUrl) input.imageUrl = toStorageKey(input.imageUrl, c.env.R2_PUBLIC_URL)
   const data = await createRecipe(db, input)
-  return c.json(buildSuccess(201, 'Recipe saved', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)), 201, {
-    Location: `/recipes/${data.id}`,
-  })
+  return c.json(
+    buildSuccess(201, 'Recipe saved', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)),
+    201,
+    {
+      Location: `/recipes/${data.id}`,
+    },
+  )
 })
 
 recipeRouter.get('/:id', async (c) => {
@@ -171,7 +183,10 @@ recipeRouter.get('/:id', async (c) => {
   if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
   const db = createDb(c.env.HYPERDRIVE.connectionString)
   const data = await getRecipe(db, id)
-  return c.json(buildSuccess(200, 'Recipe retrieved', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)), 200)
+  return c.json(
+    buildSuccess(200, 'Recipe retrieved', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)),
+    200,
+  )
 })
 
 recipeRouter.patch('/:id', requestLogger('recipe save'), async (c) => {
@@ -182,7 +197,10 @@ recipeRouter.patch('/:id', requestLogger('recipe save'), async (c) => {
   const input = RecipeUpdateSchema.parse(body)
   if (input.imageUrl) input.imageUrl = toStorageKey(input.imageUrl, c.env.R2_PUBLIC_URL)
   const data = await updateRecipe(db, id, input)
-  return c.json(buildSuccess(200, 'Recipe updated', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)), 200)
+  return c.json(
+    buildSuccess(200, 'Recipe updated', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)),
+    200,
+  )
 })
 
 recipeRouter.delete('/:id', async (c) => {

--- a/src/routes/tags.test.ts
+++ b/src/routes/tags.test.ts
@@ -54,7 +54,7 @@ describe('GET /tags', () => {
   it('returns 200 with all tags when no query param', async () => {
     const res = await request('/tags', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Tags retrieved')
     expect(body.data).toEqual(SAMPLE_TAGS)
@@ -64,7 +64,7 @@ describe('GET /tags', () => {
   it('returns all tags for empty query string', async () => {
     const res = await request('/tags?query=', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Tags retrieved')
     expect(vi.mocked(tagService.listTags)).toHaveBeenCalledOnce()
     expect(vi.mocked(tagService.searchTags)).not.toHaveBeenCalled()
@@ -73,7 +73,7 @@ describe('GET /tags', () => {
   it('returns all tags for whitespace-only query', async () => {
     const res = await request('/tags?query=   ', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Tags retrieved')
     expect(vi.mocked(tagService.listTags)).toHaveBeenCalledOnce()
     expect(vi.mocked(tagService.searchTags)).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('GET /tags', () => {
     vi.mocked(tagService.searchTags).mockResolvedValue([{ id: 1, name: 'Vegan' }])
     const res = await request('/tags?query=veg', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Tags queried')
     expect(body.data).toEqual([{ id: 1, name: 'Vegan' }])
     expect(vi.mocked(tagService.searchTags)).toHaveBeenCalledWith(expect.anything(), 'veg')
@@ -94,7 +94,7 @@ describe('GET /tags', () => {
     vi.mocked(tagService.searchTags).mockResolvedValue([])
     const res = await request('/tags?query=zzz', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.message).toBe('Tags queried')
     expect(body.data).toEqual([])
   })

--- a/src/routes/units.test.ts
+++ b/src/routes/units.test.ts
@@ -54,7 +54,7 @@ describe('GET /units', () => {
   it('returns 200 with all units', async () => {
     const res = await request('/units', USER_KEY)
     expect(res.status).toBe(200)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     expect(body.status).toBe(200)
     expect(body.message).toBe('Units retrieved')
     expect(body.data).toEqual(SAMPLE_UNITS)
@@ -63,7 +63,7 @@ describe('GET /units', () => {
 
   it('includes null abbreviation in response', async () => {
     const res = await request('/units', USER_KEY)
-    const body = await res.json() as Record<string, any>
+    const body = (await res.json()) as Record<string, any>
     const piece = body.data.find((u: { id: number }) => u.id === 3)
     expect(piece.abbreviation).toBeNull()
   })

--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -225,7 +225,10 @@ function makeRecipeDb(finalRow: { id: number; [key: string]: unknown }) {
   return { db, insertedValues }
 }
 
-function valuesFor(insertedValues: { table: unknown; vals: Record<string, unknown> }[], table: unknown) {
+function valuesFor(
+  insertedValues: { table: unknown; vals: Record<string, unknown> }[],
+  table: unknown,
+) {
   return insertedValues.filter((v) => v.table === table).map((v) => v.vals)
 }
 

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -195,10 +195,7 @@ export async function listRecipes(db: Db, page: number, limit: number): Promise<
   return rows.map((r) => ({ id: r.id, name: r.name, imageUrl: r.imageUrl ?? null }))
 }
 
-export async function searchRecipes(
-  db: Db,
-  params: RecipeSearchParams,
-): Promise<RecipeListItem[]> {
+export async function searchRecipes(db: Db, params: RecipeSearchParams): Promise<RecipeListItem[]> {
   const conditions: SQL[] = []
 
   // Mirror RecipeSpecification.buildFrom: trim each text param and skip if blank.


### PR DESCRIPTION
## Summary
- `pnpm format:check` was failing on 17 files across the repo (not tied to any recent change)
- Runs `prettier --write .`; no behavior change, formatting only
- Discovered while wiring up the CI pipeline for #16, which gates deploy on a clean `format:check` — merging this first lets that pipeline go green on a clean `main`

## Test plan
- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (171/171)