### PR TITLE
fix: correct table separator width in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Set these as [GitHub Actions repository secrets](https://github.com/settings/sec
 `wrangler.jsonc` — the account ID is treated as sensitive alongside the API token.
 
 | Secret                  | Description                                                          |
-| ----------------------- | ---------------------------------------------------------------------- |
+| ----------------------- | -------------------------------------------------------------------- |
 | `CLOUDFLARE_API_TOKEN`  | Token with `Workers Scripts:Edit` permission, scoped to this account |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID the Worker deploys to                          |
 


### PR DESCRIPTION
## Summary
- The three-way merge of #56 and #57 left the new "CI/CD secrets" table's separator row one character short of what Prettier expects, breaking `format:check` on `main` and failing the new Deploy pipeline (#16)
- No visual/content change, whitespace only

## Test plan
- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (171/171)