### PR TITLE
feat: title-case recipe/ingredient/cuisine names

### DIFF
--- a/src/lib/text.test.ts
+++ b/src/lib/text.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { toTitleCase } from './text'
+
+describe('toTitleCase', () => {
+  it('capitalizes the first letter of each word', () => {
+    expect(toTitleCase('chicken parmesan')).toBe('Chicken Parmesan')
+  })
+
+  it('lowercases already-uppercase input', () => {
+    expect(toTitleCase('CHICKEN PARMESAN')).toBe('Chicken Parmesan')
+  })
+
+  it('normalizes mixed-case input', () => {
+    expect(toTitleCase('cHiCkEn ParMESan')).toBe('Chicken Parmesan')
+  })
+
+  it('capitalizes after a hyphen', () => {
+    expect(toTitleCase('stir-fry noodles')).toBe('Stir-Fry Noodles')
+  })
+
+  it('trims leading and trailing whitespace', () => {
+    expect(toTitleCase('  olive oil  ')).toBe('Olive Oil')
+  })
+
+  it('collapses no internal whitespace, only trims edges', () => {
+    expect(toTitleCase('extra  virgin')).toBe('Extra  Virgin')
+  })
+
+  it('handles a single word', () => {
+    expect(toTitleCase('italian')).toBe('Italian')
+  })
+
+  it('does not capitalize after an apostrophe', () => {
+    expect(toTitleCase("shepherd's pie")).toBe("Shepherd's Pie")
+  })
+
+  it('capitalizes accented letters correctly', () => {
+    expect(toTitleCase('crème brûlée')).toBe('Crème Brûlée')
+    expect(toTitleCase('jalapeño')).toBe('Jalapeño')
+  })
+})

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,0 +1,11 @@
+// Capitalizes the letter after start-of-string, whitespace, or a hyphen; \p{L} (not \w) so
+// accented letters count, and apostrophes are excluded so "shepherd's pie" -> "Shepherd's Pie"
+export function toTitleCase(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(
+      /(^|[\s-])(\p{L})/gu,
+      (_, boundary: string, letter: string) => boundary + letter.toUpperCase(),
+    )
+}

--- a/src/services/cuisine-service.test.ts
+++ b/src/services/cuisine-service.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveCuisine } from './cuisine-service'
+
+function makeDb(existingRows: { id: number; name: string }[]) {
+  const insertedVals: Record<string, unknown>[] = []
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(existingRows),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((vals: Record<string, unknown>) => {
+        insertedVals.push(vals)
+        return {
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue([{ id: 99, ...vals }]),
+          })),
+        }
+      }),
+    })),
+  } as unknown as Parameters<typeof resolveCuisine>[0]
+  return { db, insertedVals }
+}
+
+describe('resolveCuisine', () => {
+  it('title-cases the name for a newly inserted cuisine', async () => {
+    const { db, insertedVals } = makeDb([])
+    const result = await resolveCuisine(db, undefined, 'ITALIAN')
+    expect(insertedVals[0].name).toBe('Italian')
+    expect(result.name).toBe('Italian')
+  })
+
+  it('leaves an existing cuisine name untouched (does not retroactively normalize)', async () => {
+    const { db } = makeDb([{ id: 1, name: 'iTALIAN' }])
+    const result = await resolveCuisine(db, undefined, 'Italian')
+    expect(result.name).toBe('iTALIAN')
+  })
+})

--- a/src/services/cuisine-service.ts
+++ b/src/services/cuisine-service.ts
@@ -2,6 +2,7 @@ import { eq, ilike } from 'drizzle-orm'
 import { createDb } from '../db/client'
 import { cuisines, type Cuisine } from '../db/schema/cuisines'
 import { BadRequestError, NotFoundError } from '../errors'
+import { toTitleCase } from '../lib/text'
 import type { NamedEntityResponse } from '../lib/types'
 
 type Db = ReturnType<typeof createDb>
@@ -39,7 +40,7 @@ export async function resolveCuisine(db: Db, id?: number | null, name?: string):
 
   const [inserted] = await db
     .insert(cuisines)
-    .values({ name: name! })
+    .values({ name: toTitleCase(name!) })
     .onConflictDoNothing({ target: cuisines.name })
     .returning()
   if (inserted) return inserted

--- a/src/services/ingredient-service.test.ts
+++ b/src/services/ingredient-service.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveIngredient } from './ingredient-service'
+
+function makeDb(existingRows: { id: number; name: string }[]) {
+  const insertedVals: Record<string, unknown>[] = []
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(existingRows),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((vals: Record<string, unknown>) => {
+        insertedVals.push(vals)
+        return {
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue([{ id: 99, ...vals }]),
+          })),
+        }
+      }),
+    })),
+  } as unknown as Parameters<typeof resolveIngredient>[0]
+  return { db, insertedVals }
+}
+
+describe('resolveIngredient', () => {
+  it('title-cases the name for a newly inserted ingredient', async () => {
+    const { db, insertedVals } = makeDb([])
+    const result = await resolveIngredient(db, undefined, 'extra virgin OLIVE oil')
+    expect(insertedVals[0].name).toBe('Extra Virgin Olive Oil')
+    expect(result.name).toBe('Extra Virgin Olive Oil')
+  })
+
+  it('leaves an existing ingredient name untouched (does not retroactively normalize)', async () => {
+    const { db } = makeDb([{ id: 1, name: 'olive OIL' }])
+    const result = await resolveIngredient(db, undefined, 'Olive Oil')
+    expect(result.name).toBe('olive OIL')
+  })
+})

--- a/src/services/ingredient-service.ts
+++ b/src/services/ingredient-service.ts
@@ -2,6 +2,7 @@ import { eq, ilike } from 'drizzle-orm'
 import { createDb } from '../db/client'
 import { ingredients, type Ingredient } from '../db/schema/ingredients'
 import { BadRequestError, NotFoundError } from '../errors'
+import { toTitleCase } from '../lib/text'
 import type { NamedEntityResponse } from '../lib/types'
 
 type Db = ReturnType<typeof createDb>
@@ -44,7 +45,7 @@ export async function resolveIngredient(
   // ingredient_name is never updated after insertion — this is the only place it is written
   const [inserted] = await db
     .insert(ingredients)
-    .values({ name: name! })
+    .values({ name: toTitleCase(name!) })
     .onConflictDoNothing({ target: ingredients.name })
     .returning()
   if (inserted) return inserted

--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -198,6 +198,7 @@ function rejectUndefined(vals: Record<string, unknown>) {
 
 function makeRecipeDb(finalRow: { id: number; [key: string]: unknown }) {
   const insertedValues: { table: unknown; vals: Record<string, unknown> }[] = []
+  const updatedValues: Record<string, unknown>[] = []
   const tx = {
     insert: vi.fn((table: unknown) => ({
       values: vi.fn((vals: Record<string, unknown>) => {
@@ -212,6 +213,7 @@ function makeRecipeDb(finalRow: { id: number; [key: string]: unknown }) {
     update: vi.fn(() => ({
       set: vi.fn((vals: Record<string, unknown>) => {
         rejectUndefined(vals)
+        updatedValues.push(vals)
         return { where: vi.fn().mockResolvedValue(undefined) }
       }),
     })),
@@ -222,7 +224,7 @@ function makeRecipeDb(finalRow: { id: number; [key: string]: unknown }) {
     transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) => cb(tx)),
     query: { recipes: { findFirst: vi.fn().mockResolvedValue(finalRow) } },
   } as unknown as Parameters<typeof createRecipe>[0] & Parameters<typeof updateRecipe>[1]
-  return { db, insertedValues }
+  return { db, insertedValues, updatedValues }
 }
 
 function valuesFor(
@@ -287,6 +289,13 @@ describe('createRecipe', () => {
     expect(ingredientValues.notes).toBeNull()
     expect(stepValues.tip).toBeNull()
   })
+
+  it('normalizes the recipe name to title case', async () => {
+    const { db, insertedValues } = makeRecipeDb(RECIPE_ROW)
+    await createRecipe(db, { ...CREATE_RECIPE_INPUT, name: 'creamy TOMATO soup' })
+    const [recipeValues] = valuesFor(insertedValues, recipes)
+    expect(recipeValues.name).toBe('Creamy Tomato Soup')
+  })
 })
 
 describe('updateRecipe', () => {
@@ -300,5 +309,11 @@ describe('updateRecipe', () => {
     const [stepValues] = valuesFor(insertedValues, recipeInstructionSteps)
     expect(ingredientValues.notes).toBeNull()
     expect(stepValues.tip).toBeNull()
+  })
+
+  it('normalizes the recipe name to title case when present', async () => {
+    const { db, updatedValues } = makeRecipeDb(RECIPE_ROW)
+    await updateRecipe(db, 1, { name: 'creamy TOMATO soup' })
+    expect(updatedValues[0].name).toBe('Creamy Tomato Soup')
   })
 })

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -10,6 +10,7 @@ import {
   tags,
 } from '../db/schema'
 import { NotFoundError } from '../errors'
+import { toTitleCase } from '../lib/text'
 import { resolveCuisine } from './cuisine-service'
 import { resolveIngredient } from './ingredient-service'
 import { resolveTag } from './tag-service'
@@ -273,7 +274,7 @@ export async function createRecipe(db: Db, input: RecipeSaveInput): Promise<Reci
     const [recipe] = await tx
       .insert(recipes)
       .values({
-        name: input.name,
+        name: toTitleCase(input.name),
         description: input.description,
         cuisineId: cuisine.id,
         author: input.author,
@@ -341,7 +342,7 @@ export async function updateRecipe(
     // nullable columns (calories, imageUrl). Non-nullable columns cannot be set to null.
     const patch: Record<string, unknown> = { updatedAt: new Date() }
 
-    if (input.name !== undefined) patch.name = input.name
+    if (input.name !== undefined) patch.name = toTitleCase(input.name)
     if (input.description !== undefined) patch.description = input.description
     if (input.author !== undefined) patch.author = input.author
     if (input.calories !== undefined) patch.calories = input.calories


### PR DESCRIPTION
## Summary
- Normalizes recipe/ingredient/cuisine names to title case server-side, resolving both open questions in #54: the transform lives in the service layer (not a Zod `.transform()`), and it only applies to new writes — existing rows matched via the case-insensitive `ilike` lookup are returned as stored, never renormalized.
- New `toTitleCase` helper in `src/lib/text.ts` (Unicode-aware via `\p{L}`, so accented letters aren't mangled; apostrophes are excluded from word boundaries so "shepherd's pie" -> "Shepherd's Pie" instead of "Shepherd'S Pie").
- Applied at every write site for these three columns: `recipeService.ts` (create + patch-when-defined), and the insert-new-row branch only of `resolveIngredient`/`resolveCuisine`.

## Test plan
- [x] `pnpm test` — 186 tests pass, including new coverage for the helper's edge cases (hyphens, apostrophes, accented letters, mixed case) and the "existing row untouched" boundary for ingredients/cuisines
- [x] `pnpm run lint` / `pnpm run format:check` — clean
- [x] Manual verification against a running dev server — not possible in this environment (local Hyperdrive emulation isn't configured); unit tests cover the behavior directly instead

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)