### PR TITLE
feat: title-case recipe/cuisine/ingredient names

### DIFF
--- a/src/lib/text.test.ts
+++ b/src/lib/text.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { toTitleCase } from './text'
+
+describe('toTitleCase', () => {
+  it('capitalizes the first letter of each word', () => {
+    expect(toTitleCase('cast iron skillet')).toBe('Cast Iron Skillet')
+  })
+
+  it('lowercases the rest of each word', () => {
+    expect(toTitleCase('CAST IRON SKILLET')).toBe('Cast Iron Skillet')
+  })
+
+  it('leaves an already title-cased value unchanged', () => {
+    expect(toTitleCase('Cast Iron Skillet')).toBe('Cast Iron Skillet')
+  })
+
+  it('handles a single word', () => {
+    expect(toTitleCase('pasta')).toBe('Pasta')
+  })
+
+  it('preserves multiple spaces between words', () => {
+    expect(toTitleCase('cast  iron')).toBe('Cast  Iron')
+  })
+
+  it('handles an empty string', () => {
+    expect(toTitleCase('')).toBe('')
+  })
+
+  it('leaves non-letter leading characters unaffected', () => {
+    expect(toTitleCase('5-spice powder')).toBe('5-spice Powder')
+  })
+})

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,0 +1,8 @@
+export function toTitleCase(value: string): string {
+  return value
+    .split(' ')
+    .map((word) =>
+      word.length === 0 ? word : word[0]!.toUpperCase() + word.slice(1).toLowerCase(),
+    )
+    .join(' ')
+}

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -338,6 +338,48 @@ describe('POST /recipes', () => {
     )
   })
 
+  it('normalizes recipe, cuisine, and ingredient names to title case', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: {
+        ...SAVE_BODY,
+        name: 'spaghetti BOLOGNESE',
+        cuisine: { name: 'ITALIAN' },
+        ingredients: [{ name: 'ground beef', unitId: 1, quantity: 200 }],
+      },
+    })
+    expect(res.status).toBe(201)
+    expect(vi.mocked(recipeService.createRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: 'Spaghetti Bolognese',
+        cuisine: { name: 'Italian' },
+        ingredients: [expect.objectContaining({ name: 'Ground Beef' })],
+      }),
+    )
+  })
+
+  it('trims surrounding whitespace before title-casing names', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: {
+        ...SAVE_BODY,
+        name: '  spaghetti bolognese  ',
+        cuisine: { name: ' italian ' },
+        ingredients: [{ name: ' ground beef ', unitId: 1, quantity: 200 }],
+      },
+    })
+    expect(res.status).toBe(201)
+    expect(vi.mocked(recipeService.createRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: 'Spaghetti Bolognese',
+        cuisine: { name: 'Italian' },
+        ingredients: [expect.objectContaining({ name: 'Ground Beef' })],
+      }),
+    )
+  })
+
   it('returns 400 when name is too short', async () => {
     const res = await request('/recipes', {
       method: 'POST',
@@ -520,6 +562,26 @@ describe('PATCH /recipes/:id', () => {
     const res = await request('/recipes/1', { method: 'PATCH', body: { ingredients: [] } })
     expect(res.status).toBe(400)
     expect(vi.mocked(recipeService.updateRecipe)).not.toHaveBeenCalled()
+  })
+
+  it('normalizes an updated name to title case', async () => {
+    vi.mocked(recipeService.updateRecipe).mockResolvedValue(FULL_RECIPE)
+    await request('/recipes/1', { method: 'PATCH', body: { name: 'updated PASTA' } })
+    expect(vi.mocked(recipeService.updateRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      1,
+      expect.objectContaining({ name: 'Updated Pasta' }),
+    )
+  })
+
+  it('leaves name untouched when omitted from the patch', async () => {
+    vi.mocked(recipeService.updateRecipe).mockResolvedValue(FULL_RECIPE)
+    await request('/recipes/1', { method: 'PATCH', body: { calories: 500 } })
+    expect(vi.mocked(recipeService.updateRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      1,
+      expect.not.objectContaining({ name: expect.anything() }),
+    )
   })
 
   it('accepts explicit null id on cuisine, ingredients, and tags', async () => {

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -4,6 +4,7 @@ import { createDb } from '../db/client'
 import { buildSuccess } from '../lib/response'
 import { BadRequestError } from '../errors'
 import { toStorageKey, withPublicImageUrl } from '../lib/image-url'
+import { toTitleCase } from '../lib/text'
 import { requestLogger } from '../middleware/request-logger'
 import {
   createRecipe,
@@ -19,7 +20,10 @@ export const recipeRouter = new Hono<{ Bindings: CloudflareBindings }>()
 const CuisineInputSchema = z
   .object({
     id: z.number().int().positive().nullish(),
-    name: z.string().optional(),
+    name: z
+      .string()
+      .transform((v) => toTitleCase(v.trim()))
+      .optional(),
   })
   .refine((c) => c.id != null || (c.name?.trim().length ?? 0) > 0, {
     message: 'Cuisine request must have either an ID or a name.',
@@ -28,7 +32,10 @@ const CuisineInputSchema = z
 const IngredientInputSchema = z
   .object({
     id: z.number().int().positive().nullish(),
-    name: z.string().optional(),
+    name: z
+      .string()
+      .transform((v) => toTitleCase(v.trim()))
+      .optional(),
     unitId: z.number().int().positive(),
     quantity: z.number().positive(),
     notes: z.string().nullish(),
@@ -37,6 +44,8 @@ const IngredientInputSchema = z
     message: 'Ingredient request must have either an ID or a name.',
   })
 
+// name is intentionally left as-is here — tags are out of scope for title-case
+// normalization (#54), unlike Cuisine/Ingredient name above.
 const TagInputSchema = z
   .object({
     id: z.number().int().positive().nullish(),
@@ -58,7 +67,8 @@ const RecipeSaveSchema = z.object({
   name: z
     .string()
     .min(2, 'Recipe name must be between 2 to 150 characters.')
-    .max(150, 'Recipe name must be between 2 to 150 characters.'),
+    .max(150, 'Recipe name must be between 2 to 150 characters.')
+    .transform((v) => toTitleCase(v.trim())),
   description: z.string().default(''),
   calories: z.number().int().min(0).max(32767).nullable().optional(),
   servings: z.number().int().positive('Servings must be a more than zero.').max(32767),
@@ -77,6 +87,7 @@ const RecipeUpdateSchema = z.object({
     .string()
     .min(2, 'Recipe name must be between 2 to 150 characters.')
     .max(150, 'Recipe name must be between 2 to 150 characters.')
+    .transform((v) => toTitleCase(v.trim()))
     .optional(),
   description: z.string().optional(),
   calories: z.number().int().min(0).max(32767).nullable().optional(),


### PR DESCRIPTION
## Summary
- Recipe name, cuisine name, and ingredient name are normalized to
  title case server-side on create/update, via `.transform()` on
  the Zod schemas in `src/routes/recipes.ts` (the only write path
  for cuisine/ingredient names — both are otherwise GET-only
  resources, resolved by name/id from the nested recipe payload).
- New `src/lib/text.ts` — pure `toTitleCase()` helper.
- Names are trimmed before title-casing so `"Italian "` and
  `"Italian"` don't become separate rows (resolveCuisine/
  resolveIngredient dedup via exact case-insensitive `ilike`).
- Tag names are intentionally left untouched — out of scope per
  the issue.

## Design decisions (open questions from the issue)
- **Where normalization lives**: Zod schema layer, not a service
  helper — every name input already flows through these schemas,
  so this is the single point that covers 100% of the write
  surface (verified: `cuisines.ts`/`ingredients.ts` are GET-only;
  `resolveCuisine`/`resolveIngredient` are only ever called from
  `recipeService.ts` with values sourced from these schemas).
- **New writes only, no backfill**: existing rows keep their
  current casing. Filed #62 to track a backfill if that's wanted
  later.

Also filed #61 for a pre-existing gap surfaced while reviewing this
(Cuisine/Ingredient name has no length validation) — not fixed here
to avoid unrelated scope/behavior changes in this PR.

Confirmed there's no equivalent logic in `recipe-service` — this is
new behavior, not a port.

## Test plan
- [x] POST /recipes normalizes name, cuisine.name, ingredient.name
- [x] PATCH /recipes/:id normalizes an updated name
- [x] PATCH without `name` leaves it out of the patch untouched
- [x] Leading/trailing whitespace is trimmed before title-casing
- [x] `pnpm test` passes (182 tests)
- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)