### PR TITLE
fix: return JSON envelope for unmatched routes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,26 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { buildError } from './lib/response'
+
+// index.ts wires the real app to Cloudflare bindings (Hyperdrive, R2, secrets), which
+// aren't available under vitest, so the notFound handler is verified in isolation
+// using the same registration it uses in index.ts rather than importing the app itself.
+function buildTestApp() {
+  const app = new Hono()
+  app.notFound((c) => c.json(buildError(404, 'Route not found', c.req.path), 404))
+  return app
+}
+
+const app = buildTestApp()
+
+describe('notFound', () => {
+  it('returns the standard error envelope for an unmatched route', async () => {
+    const res = await app.request('/nope')
+    const body = (await res.json()) as Record<string, any>
+
+    expect(res.status).toBe(404)
+    expect(body.message).toBe('Route not found')
+    expect(body.path).toBe('/nope')
+    expect('data' in body).toBe(false)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { authMiddleware } from './middleware/auth'
 import { errorHandler } from './middleware/error-handler'
 import { rateLimiterMiddleware } from './middleware/rate-limiter'
+import { buildError } from './lib/response'
 import { cuisineRouter } from './routes/cuisines'
 import { ingredientRouter } from './routes/ingredients'
 import { tagRouter } from './routes/tags'
@@ -12,6 +13,7 @@ import { recipeRouter } from './routes/recipes'
 const app = new Hono<{ Bindings: CloudflareBindings }>()
 
 app.onError(errorHandler)
+app.notFound((c) => c.json(buildError(404, 'Route not found', c.req.path), 404))
 
 app.get('/health', (c) => c.json({ status: 'ok' }))
 


### PR DESCRIPTION
## Summary
- Hono's default 404 for unregistered routes was plain text, inconsistent with every registered route's structured error envelope (`{ timestamp, status, message, path }`)
- Added `app.notFound` to route unmatched paths through `buildError` like every other error path already does

## Test plan
- [x] `pnpm test` — 897 passed
- [x] `pnpm run lint` — clean
- [x] Added `src/index.test.ts` covering the envelope shape on an unmatched route