### PR TITLE
fix: null handling for recipe description/calories

### DIFF
--- a/src/db/schema/recipes.ts
+++ b/src/db/schema/recipes.ts
@@ -15,9 +15,7 @@ export const recipes = recipeservice.table('recipes', {
     .notNull()
     .references(() => cuisines.id),
   author: varchar('author', { length: 255 }).notNull(),
-  // Nullable intentionally: DB column is nullable despite Java entity using a primitive short.
-  // The issue spec and actual DB state take precedence over the Java source here.
-  calories: smallint('calories'),
+  calories: smallint('calories').notNull(),
   servings: smallint('servings').notNull(),
   cookingTime: smallint('cooking_time').notNull(),
   preparationTime: smallint('preparation_time').notNull(),

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -61,6 +61,7 @@ const FULL_RECIPE: recipeService.RecipeResponse = {
 const SAVE_BODY = {
   name: 'Pasta',
   description: 'A simple pasta dish',
+  calories: 450,
   servings: 2,
   cookingTime: 10,
   preparationTime: 5,
@@ -403,6 +404,40 @@ describe('POST /recipes', () => {
     expect(res.status).toBe(201)
   })
 
+  it('returns 400 for an explicit null calories', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, calories: null },
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Calories is required and cannot be null.')
+    expect(vi.mocked(recipeService.createRecipe)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when calories is omitted', async () => {
+    const bodyWithoutCalories: Record<string, unknown> = { ...SAVE_BODY }
+    delete bodyWithoutCalories.calories
+    const res = await request('/recipes', { method: 'POST', body: bodyWithoutCalories })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Calories is required and cannot be null.')
+    expect(vi.mocked(recipeService.createRecipe)).not.toHaveBeenCalled()
+  })
+
+  it('accepts a null description', async () => {
+    vi.mocked(recipeService.createRecipe).mockResolvedValue(FULL_RECIPE)
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, description: null },
+    })
+    expect(res.status).toBe(201)
+    expect(vi.mocked(recipeService.createRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ description: null }),
+    )
+  })
+
   it('accepts explicit null id on cuisine, ingredients, and tags', async () => {
     const res = await request('/recipes', {
       method: 'POST',
@@ -485,12 +520,20 @@ describe('PATCH /recipes/:id', () => {
 
   it('passes only provided fields to service', async () => {
     vi.mocked(recipeService.updateRecipe).mockResolvedValue(FULL_RECIPE)
-    await request('/recipes/1', { method: 'PATCH', body: { calories: null } })
+    await request('/recipes/1', { method: 'PATCH', body: { description: null } })
     expect(vi.mocked(recipeService.updateRecipe)).toHaveBeenCalledWith(
       expect.anything(),
       1,
-      expect.objectContaining({ calories: null }),
+      expect.objectContaining({ description: null }),
     )
+  })
+
+  it('returns 400 for an explicit null calories', async () => {
+    const res = await request('/recipes/1', { method: 'PATCH', body: { calories: null } })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Calories cannot be null.')
+    expect(vi.mocked(recipeService.updateRecipe)).not.toHaveBeenCalled()
   })
 
   it('strips the public URL prefix before storing a presigned imageUrl', async () => {

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -59,8 +59,8 @@ const RecipeSaveSchema = z.object({
     .string()
     .min(2, 'Recipe name must be between 2 to 150 characters.')
     .max(150, 'Recipe name must be between 2 to 150 characters.'),
-  description: z.string().default(''),
-  calories: z.number().int().min(0).max(32767).nullable().optional(),
+  description: z.string().nullable().optional(),
+  calories: z.number({ error: 'Calories is required and cannot be null.' }).int().min(0).max(32767),
   servings: z.number().int().positive('Servings must be a more than zero.').max(32767),
   cookingTime: z.number().int().min(0, 'Cooking time cannot be negative.').max(32767),
   preparationTime: z.number().int().positive('Preparation time cannot be zero minutes.').max(32767),
@@ -78,8 +78,8 @@ const RecipeUpdateSchema = z.object({
     .min(2, 'Recipe name must be between 2 to 150 characters.')
     .max(150, 'Recipe name must be between 2 to 150 characters.')
     .optional(),
-  description: z.string().optional(),
-  calories: z.number().int().min(0).max(32767).nullable().optional(),
+  description: z.string().nullable().optional(),
+  calories: z.number({ error: 'Calories cannot be null.' }).int().min(0).max(32767).optional(),
   servings: z.number().int().positive().max(32767).optional(),
   cookingTime: z.number().int().min(0).max(32767).optional(),
   preparationTime: z.number().int().positive().max(32767).optional(),

--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -255,6 +255,7 @@ const RECIPE_ROW = {
 const CREATE_RECIPE_INPUT: Parameters<typeof createRecipe>[1] = {
   name: 'Pasta',
   description: '',
+  calories: 450,
   servings: 2,
   cookingTime: 10,
   preparationTime: 5,
@@ -265,11 +266,11 @@ const CREATE_RECIPE_INPUT: Parameters<typeof createRecipe>[1] = {
 }
 
 describe('createRecipe', () => {
-  it('inserts null, not undefined, when calories and imageUrl are omitted', async () => {
+  it('inserts null, not undefined, when imageUrl is omitted', async () => {
     const { db, insertedValues } = makeRecipeDb(RECIPE_ROW)
     await createRecipe(db, CREATE_RECIPE_INPUT)
     const [recipeValues] = valuesFor(insertedValues, recipes)
-    expect(recipeValues.calories).toBeNull()
+    expect(recipeValues.calories).toBe(CREATE_RECIPE_INPUT.calories)
     expect(recipeValues.imageUrl).toBeNull()
   })
 
@@ -296,6 +297,13 @@ describe('createRecipe', () => {
     const [recipeValues] = valuesFor(insertedValues, recipes)
     expect(recipeValues.name).toBe('Creamy Tomato Soup')
   })
+
+  it('inserts empty string, not null, when description is null', async () => {
+    const { db, insertedValues } = makeRecipeDb(RECIPE_ROW)
+    await createRecipe(db, { ...CREATE_RECIPE_INPUT, description: null })
+    const [recipeValues] = valuesFor(insertedValues, recipes)
+    expect(recipeValues.description).toBe('')
+  })
 })
 
 describe('updateRecipe', () => {
@@ -315,5 +323,11 @@ describe('updateRecipe', () => {
     const { db, updatedValues } = makeRecipeDb(RECIPE_ROW)
     await updateRecipe(db, 1, { name: 'creamy TOMATO soup' })
     expect(updatedValues[0].name).toBe('Creamy Tomato Soup')
+  })
+
+  it('clears description to empty string, not null, when set to null', async () => {
+    const { db, updatedValues } = makeRecipeDb(RECIPE_ROW)
+    await updateRecipe(db, 1, { description: null })
+    expect(updatedValues[0].description).toBe('')
   })
 })

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -31,8 +31,8 @@ export type StepInput = { stepNumber: number; description: string; tip?: string 
 
 export type RecipeSaveInput = {
   name: string
-  description: string
-  calories?: number | null
+  description?: string | null
+  calories: number
   servings: number
   cookingTime: number
   preparationTime: number
@@ -46,8 +46,8 @@ export type RecipeSaveInput = {
 
 export type RecipeUpdateInput = {
   name?: string
-  description?: string
-  calories?: number | null
+  description?: string | null
+  calories?: number
   servings?: number
   cookingTime?: number
   preparationTime?: number
@@ -275,14 +275,15 @@ export async function createRecipe(db: Db, input: RecipeSaveInput): Promise<Reci
       .insert(recipes)
       .values({
         name: toTitleCase(input.name),
-        description: input.description,
+        description: input.description ?? '',
         cuisineId: cuisine.id,
         author: input.author,
-        // ?? null on every nullable optional field below: the postgres driver rejects
+        // ?? null on nullable optional fields below: the postgres driver rejects
         // `undefined` bind params outright, so an omitted field must be coerced. Applies
         // wherever an insert takes a nullable-no-default column straight from input
-        // (see also notes/tip in the ingredient/step inserts further down).
-        calories: input.calories ?? null,
+        // (see also notes/tip in the ingredient/step inserts further down). calories is
+        // NOT NULL and required by RecipeSaveInput, so it needs no such fallback.
+        calories: input.calories,
         servings: input.servings,
         cookingTime: input.cookingTime,
         preparationTime: input.preparationTime,
@@ -339,11 +340,13 @@ export async function updateRecipe(
 
     // updatedAt is always set explicitly on PATCH, as required by the spec.
     // Note: unlike the Java source (which ignores null fields), null here nullifies
-    // nullable columns (calories, imageUrl). Non-nullable columns cannot be set to null.
+    // nullable columns (imageUrl). description is non-nullable in the DB, so a null
+    // input clears it to '' instead. calories rejects null at the request-validation
+    // layer, so it never arrives here as null.
     const patch: Record<string, unknown> = { updatedAt: new Date() }
 
     if (input.name !== undefined) patch.name = toTitleCase(input.name)
-    if (input.description !== undefined) patch.description = input.description
+    if (input.description !== undefined) patch.description = input.description ?? ''
     if (input.author !== undefined) patch.author = input.author
     if (input.calories !== undefined) patch.calories = input.calories
     if (input.servings !== undefined) patch.servings = input.servings


### PR DESCRIPTION
## Summary
- `description` now accepts `null` (and omitted) on create/update, clearing to `''` in the service layer instead of returning 400 for an explicit `null`
- `calories` now matches the DB's `NOT NULL` constraint: required on create, and `null` is rejected with a clear message on both create and update instead of being silently passed through (the DB column is `NOT NULL`, same as `servings`/`cookingTime`/`preparationTime` — a stale schema comment had claimed otherwise)

Fixes #65

## Test plan
- [x] `pnpm test` — 903 passed
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [x] Added regression tests for: null description on create/update, null calories rejected (create/update), missing calories rejected on create