### PR TITLE
fix: delete R2 image when recipe is deleted

### DIFF
--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -13,6 +13,7 @@ type TestBindings = {
   USER_API_KEY: string
   ADMIN_API_KEY: string
   HYPERDRIVE: { connectionString: string }
+  IMAGE_BUCKET: R2Bucket
   R2_PUBLIC_URL: string
 }
 
@@ -22,6 +23,7 @@ const TEST_ENV: TestBindings = {
   USER_API_KEY: USER_KEY,
   ADMIN_API_KEY: ADMIN_KEY,
   HYPERDRIVE: { connectionString: 'postgresql://test' },
+  IMAGE_BUCKET: {} as unknown as R2Bucket,
   R2_PUBLIC_URL: 'https://pub-test.r2.dev',
 }
 
@@ -606,7 +608,12 @@ describe('DELETE /recipes/:id', () => {
     vi.mocked(recipeService.deleteRecipe).mockResolvedValue(undefined)
     const res = await request('/recipes/1', { method: 'DELETE', apiKey: ADMIN_KEY })
     expect(res.status).toBe(204)
-    expect(vi.mocked(recipeService.deleteRecipe)).toHaveBeenCalledWith(expect.anything(), 1)
+    expect(vi.mocked(recipeService.deleteRecipe)).toHaveBeenCalledWith(
+      expect.anything(),
+      1,
+      TEST_ENV.IMAGE_BUCKET,
+      TEST_ENV.R2_PUBLIC_URL,
+    )
   })
 
   it('returns 401 without admin key (user key is rejected)', async () => {

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -207,6 +207,6 @@ recipeRouter.delete('/:id', async (c) => {
   const id = Number(c.req.param('id'))
   if (isNaN(id)) throw new BadRequestError('Invalid recipe id')
   const db = createDb(c.env.HYPERDRIVE.connectionString)
-  await deleteRecipe(db, id)
+  await deleteRecipe(db, id, c.env.IMAGE_BUCKET, c.env.R2_PUBLIC_URL)
   return c.body(null, 204)
 })

--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it, vi } from 'vitest'
-import { createRecipe, listRecipes, searchRecipes, updateRecipe } from './recipeService'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createRecipe,
+  deleteRecipe,
+  listRecipes,
+  searchRecipes,
+  updateRecipe,
+} from './recipeService'
 import { recipeIngredients, recipeInstructionSteps, recipes } from '../db/schema'
+import { NotFoundError } from '../errors'
+import { deleteImage } from './image-service'
 
 vi.mock('./cuisine-service', () => ({
   resolveCuisine: vi.fn().mockResolvedValue({ id: 1, name: 'Italian' }),
@@ -13,6 +21,9 @@ vi.mock('./unit-service', () => ({
 }))
 vi.mock('./tag-service', () => ({
   resolveTag: vi.fn().mockResolvedValue({ id: 5, name: 'Quick' }),
+}))
+vi.mock('./image-service', () => ({
+  deleteImage: vi.fn(),
 }))
 
 function makeDb(rows: { id: number; name: string; imageUrl: string | null }[]) {
@@ -329,5 +340,99 @@ describe('updateRecipe', () => {
     const { db, updatedValues } = makeRecipeDb(RECIPE_ROW)
     await updateRecipe(db, 1, { description: null })
     expect(updatedValues[0].description).toBe('')
+  })
+})
+
+const PUBLIC_URL = 'https://pub-test.r2.dev'
+
+function makeBucket() {
+  return {} as unknown as R2Bucket
+}
+
+function makeDeleteDb(row: { id: number; imageUrl: string | null } | undefined) {
+  return {
+    delete: vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue(row ? [row] : []),
+      })),
+    })),
+  } as unknown as Parameters<typeof deleteRecipe>[0]
+}
+
+describe('deleteRecipe', () => {
+  beforeEach(() => {
+    vi.mocked(deleteImage).mockReset()
+  })
+
+  it('throws NotFoundError when no row is deleted', async () => {
+    const db = makeDeleteDb(undefined)
+
+    await expect(deleteRecipe(db, 999, makeBucket(), PUBLIC_URL)).rejects.toThrow(
+      new NotFoundError('Recipe not found with id: 999'),
+    )
+    expect(vi.mocked(deleteImage)).not.toHaveBeenCalled()
+  })
+
+  it('skips image deletion when the recipe has no imageUrl', async () => {
+    const db = makeDeleteDb({ id: 1, imageUrl: null })
+
+    await deleteRecipe(db, 1, makeBucket(), PUBLIC_URL)
+
+    expect(vi.mocked(deleteImage)).not.toHaveBeenCalled()
+  })
+
+  it('deletes the R2 object using the stored key', async () => {
+    const db = makeDeleteDb({ id: 1, imageUrl: 'recipes/abc-123.jpg' })
+    vi.mocked(deleteImage).mockResolvedValue(undefined)
+    const bucket = makeBucket()
+
+    await deleteRecipe(db, 1, bucket, PUBLIC_URL)
+
+    expect(vi.mocked(deleteImage)).toHaveBeenCalledWith(bucket, 'recipes/abc-123.jpg')
+  })
+
+  it('resolves a legacy full-URL imageUrl to a storage key before deleting', async () => {
+    const db = makeDeleteDb({ id: 1, imageUrl: `${PUBLIC_URL}/recipes/legacy.jpg` })
+    vi.mocked(deleteImage).mockResolvedValue(undefined)
+
+    await deleteRecipe(db, 1, makeBucket(), PUBLIC_URL)
+
+    expect(vi.mocked(deleteImage)).toHaveBeenCalledWith(expect.anything(), 'recipes/legacy.jpg')
+  })
+
+  it('retries a failed R2 delete and succeeds without throwing', async () => {
+    vi.useFakeTimers()
+    const db = makeDeleteDb({ id: 1, imageUrl: 'recipes/abc-123.jpg' })
+    vi.mocked(deleteImage)
+      .mockRejectedValueOnce(new Error('R2 unavailable'))
+      .mockRejectedValueOnce(new Error('R2 unavailable'))
+      .mockResolvedValueOnce(undefined)
+
+    const promise = deleteRecipe(db, 1, makeBucket(), PUBLIC_URL)
+    await vi.runAllTimersAsync()
+    await promise
+
+    expect(vi.mocked(deleteImage)).toHaveBeenCalledTimes(3)
+    vi.useRealTimers()
+  })
+
+  it('gives up after 3 attempts, logs the orphaned key, and does not fail the delete', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const db = makeDeleteDb({ id: 1, imageUrl: 'recipes/abc-123.jpg' })
+    vi.mocked(deleteImage).mockRejectedValue(new Error('R2 unavailable'))
+
+    const promise = deleteRecipe(db, 1, makeBucket(), PUBLIC_URL)
+    await vi.runAllTimersAsync()
+    await expect(promise).resolves.toBeUndefined()
+
+    expect(vi.mocked(deleteImage)).toHaveBeenCalledTimes(3)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"recipeId":1'))
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"imageKey":"recipes/abc-123.jpg"'),
+    )
+
+    errorSpy.mockRestore()
+    vi.useRealTimers()
   })
 })

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -10,11 +10,16 @@ import {
   tags,
 } from '../db/schema'
 import { NotFoundError } from '../errors'
+import { toStorageKey } from '../lib/image-url'
 import { toTitleCase } from '../lib/text'
 import { resolveCuisine } from './cuisine-service'
 import { resolveIngredient } from './ingredient-service'
+import { deleteImage } from './image-service'
 import { resolveTag } from './tag-service'
 import { resolveUnit } from './unit-service'
+
+const IMAGE_DELETE_MAX_ATTEMPTS = 3
+const IMAGE_DELETE_BACKOFF_MS = 200
 
 type Db = ReturnType<typeof createDb>
 
@@ -402,9 +407,52 @@ export async function updateRecipe(
   return fetchFullRecipe(db, id)
 }
 
-export async function deleteRecipe(db: Db, id: number): Promise<void> {
+export async function deleteRecipe(
+  db: Db,
+  id: number,
+  bucket: R2Bucket,
+  publicUrl: string,
+): Promise<void> {
   // Single atomic statement: .returning() gives us a row if the delete hit something,
   // empty array if not. Avoids the findFirst + delete TOCTOU race.
-  const [deleted] = await db.delete(recipes).where(eq(recipes.id, id)).returning({ id: recipes.id })
+  const [deleted] = await db
+    .delete(recipes)
+    .where(eq(recipes.id, id))
+    .returning({ id: recipes.id, imageUrl: recipes.imageUrl })
   if (!deleted) throw new NotFoundError(`Recipe not found with id: ${id}`)
+
+  if (deleted.imageUrl) {
+    await deleteRecipeImage(bucket, toStorageKey(deleted.imageUrl, publicUrl), id)
+  }
+}
+
+// The recipe row is already gone by the time this runs, so a failure here can't be
+// surfaced to the caller without falsely implying the delete failed. Retry a bounded
+// number of times, then log the orphaned key for manual/sweep cleanup rather than
+// blocking or failing the recipe delete response.
+async function deleteRecipeImage(bucket: R2Bucket, key: string, recipeId: number): Promise<void> {
+  for (let attempt = 1; attempt <= IMAGE_DELETE_MAX_ATTEMPTS; attempt++) {
+    try {
+      await deleteImage(bucket, key)
+      return
+    } catch (err) {
+      if (attempt === IMAGE_DELETE_MAX_ATTEMPTS) {
+        console.error(
+          JSON.stringify({
+            message: 'Failed to delete orphaned recipe image from R2',
+            recipeId,
+            imageKey: key,
+            attempts: attempt,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        )
+        return
+      }
+      await sleep(IMAGE_DELETE_BACKOFF_MS * attempt)
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
## Summary
- `deleteRecipe` now also deletes the recipe's R2 image object (reusing `deleteImage`), so `DELETE /recipes/:id` no longer orphans images in the `recipe-images` bucket.
- Resolves legacy full-URL `imageUrl` values to a storage key via `toStorageKey` before deleting, so both key-only and legacy full-URL rows are handled.
- If the R2 delete fails after the DB row is gone, retries up to 3 times with linear backoff, then logs the orphaned recipe id + key and returns without failing the delete response.

## Test plan
- [x] `pnpm test` — 199 tests pass, including new `deleteRecipe` coverage (no-op on null imageUrl, key deletion, legacy URL resolution, retry-then-succeed, retry-exhausted-then-log)
- [x] `pnpm run lint`
- [x] `pnpm run format:check`

## Review notes
Reviewed by api-reviewer; no blocking issues. Should-fix / notes for the human reviewer:
- **Retries don't distinguish transient vs. permanent failures**: `deleteImage` throws `BadRequestError` synchronously for a malformed key (e.g. a legacy `imageUrl` whose prefix no longer matches `publicUrl`). That's deterministic, not transient, but currently gets retried 3x with backoff anyway. Consider special-casing `BadRequestError` to skip straight to log-and-return.
- **"Non-blocking" comment is slightly inaccurate**: the R2 delete (with retries/backoff) is awaited before the response returns, so a slow/unavailable bucket adds up to ~600ms + R2 round-trip latency to `DELETE /recipes/:id` — it never *fails* the response, but it does *delay* it. Could wire through `c.executionCtx.waitUntil(...)` for genuine fire-and-forget, or just tighten the comment's wording.
- **Same orphan bug exists on the update path**: `PATCH /recipes/:id` overwrites `imageUrl` without deleting the previous R2 object when an image is replaced. Out of scope for issue #67 (delete-only), but worth its own follow-up issue.

Fixes #67