### PR TITLE
Tighten server-side max image size as a backstop

### DIFF
--- a/src/lib/image-constraints.ts
+++ b/src/lib/image-constraints.ts
@@ -1,5 +1,7 @@
 export const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5 MB
 
+export const MAX_IMAGE_SIZE_ERROR_MESSAGE = `File exceeds ${MAX_IMAGE_SIZE / (1024 * 1024)}MB limit`
+
 export const ALLOWED_IMAGE_TYPES = new Set([
   'image/jpeg',
   'image/png',

--- a/src/lib/image-constraints.ts
+++ b/src/lib/image-constraints.ts
@@ -1,4 +1,4 @@
-export const MAX_IMAGE_SIZE = 25 * 1024 * 1024 // 25 MB
+export const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5 MB
 
 export const ALLOWED_IMAGE_TYPES = new Set([
   'image/jpeg',

--- a/src/routes/images.test.ts
+++ b/src/routes/images.test.ts
@@ -119,16 +119,16 @@ describe('POST /recipes/images', () => {
     expect(vi.mocked(imageService.uploadImage)).not.toHaveBeenCalled()
   })
 
-  it('returns 400 when service rejects file exceeding 25MB', async () => {
+  it('returns 400 when service rejects file exceeding 5MB', async () => {
     vi.mocked(imageService.uploadImage).mockRejectedValue(
-      new BadRequestError('File exceeds 25MB limit'),
+      new BadRequestError('File exceeds 5MB limit'),
     )
 
     const res = await uploadRequest(makeFormData(makeFile()), USER_KEY)
     const body = (await res.json()) as Record<string, any>
 
     expect(res.status).toBe(400)
-    expect(body.message).toBe('File exceeds 25MB limit')
+    expect(body.message).toBe('File exceeds 5MB limit')
   })
 
   it('propagates BadRequestError from service as 400 (error handler integration)', async () => {

--- a/src/services/image-service.test.ts
+++ b/src/services/image-service.test.ts
@@ -30,13 +30,13 @@ describe('uploadImage', () => {
     expect(vi.mocked(bucket.put)).not.toHaveBeenCalled()
   })
 
-  it('throws BadRequestError for a file exceeding 25MB', async () => {
+  it('throws BadRequestError for a file exceeding 5MB', async () => {
     const bucket = makeBucket()
-    // Use a mock object so we don't allocate 25MB in the test
-    const file = { size: 25 * 1024 * 1024 + 1, type: 'image/jpeg' } as unknown as File
+    // Use a mock object so we don't allocate 5MB in the test
+    const file = { size: 5 * 1024 * 1024 + 1, type: 'image/jpeg' } as unknown as File
 
     await expect(uploadImage(bucket, PUBLIC_URL, file)).rejects.toThrow(
-      new BadRequestError('File exceeds 25MB limit'),
+      new BadRequestError('File exceeds 5MB limit'),
     )
     expect(vi.mocked(bucket.put)).not.toHaveBeenCalled()
   })

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -11,7 +11,7 @@ export async function uploadImage(
   }
 
   if (file.size > MAX_IMAGE_SIZE) {
-    throw new BadRequestError('File exceeds 25MB limit')
+    throw new BadRequestError('File exceeds 5MB limit')
   }
 
   const contentType = file.type

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -1,5 +1,10 @@
 import { BadRequestError } from '../errors'
-import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE, buildImageKey } from '../lib/image-constraints'
+import {
+  ALLOWED_IMAGE_TYPES,
+  MAX_IMAGE_SIZE,
+  MAX_IMAGE_SIZE_ERROR_MESSAGE,
+  buildImageKey,
+} from '../lib/image-constraints'
 
 export async function uploadImage(
   bucket: R2Bucket,
@@ -11,7 +16,7 @@ export async function uploadImage(
   }
 
   if (file.size > MAX_IMAGE_SIZE) {
-    throw new BadRequestError('File exceeds 5MB limit')
+    throw new BadRequestError(MAX_IMAGE_SIZE_ERROR_MESSAGE)
   }
 
   const contentType = file.type

--- a/src/services/presign-service.test.ts
+++ b/src/services/presign-service.test.ts
@@ -38,10 +38,10 @@ describe('createPresignedUpload', () => {
     expect(getSignedUrlMock).not.toHaveBeenCalled()
   })
 
-  it('throws BadRequestError for contentLength exceeding 25MB', async () => {
+  it('throws BadRequestError for contentLength exceeding 5MB', async () => {
     await expect(
-      createPresignedUpload(CREDENTIALS, BUCKET, 'image/jpeg', 25 * 1024 * 1024 + 1),
-    ).rejects.toThrow(new BadRequestError('File exceeds 25MB limit'))
+      createPresignedUpload(CREDENTIALS, BUCKET, 'image/jpeg', 5 * 1024 * 1024 + 1),
+    ).rejects.toThrow(new BadRequestError('File exceeds 5MB limit'))
     expect(getSignedUrlMock).not.toHaveBeenCalled()
   })
 

--- a/src/services/presign-service.ts
+++ b/src/services/presign-service.ts
@@ -33,7 +33,7 @@ export async function createPresignedUpload(
     throw new BadRequestError('contentLength must be greater than 0')
   }
   if (contentLength > MAX_IMAGE_SIZE) {
-    throw new BadRequestError('File exceeds 25MB limit')
+    throw new BadRequestError('File exceeds 5MB limit')
   }
 
   const key = buildImageKey(contentType)

--- a/src/services/presign-service.ts
+++ b/src/services/presign-service.ts
@@ -1,7 +1,12 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { BadRequestError } from '../errors'
-import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE, buildImageKey } from '../lib/image-constraints'
+import {
+  ALLOWED_IMAGE_TYPES,
+  MAX_IMAGE_SIZE,
+  MAX_IMAGE_SIZE_ERROR_MESSAGE,
+  buildImageKey,
+} from '../lib/image-constraints'
 
 // Single-use in practice: each call mints a fresh, randomly-keyed object, so a
 // leaked URL only ever grants a PUT to that one key, not an update to an existing image.
@@ -33,7 +38,7 @@ export async function createPresignedUpload(
     throw new BadRequestError('contentLength must be greater than 0')
   }
   if (contentLength > MAX_IMAGE_SIZE) {
-    throw new BadRequestError('File exceeds 5MB limit')
+    throw new BadRequestError(MAX_IMAGE_SIZE_ERROR_MESSAGE)
   }
 
   const key = buildImageKey(contentType)


### PR DESCRIPTION
## Summary
- Lower `MAX_IMAGE_SIZE` in `src/lib/image-constraints.ts` from 25MB to 5MB
- Derive the "exceeds limit" error message from `MAX_IMAGE_SIZE` via a
  shared `MAX_IMAGE_SIZE_ERROR_MESSAGE` constant, used by both
  `presign-service.ts` and `image-service.ts`, so the two can't drift
  out of sync with the limit again
- Update tests referencing the old 25MB limit

This is a defense-in-depth backstop — client-side compression in
foodies-finds keeps well-behaved uploads small, but nothing previously
stopped a non-browser client (e.g. a script hitting the presign
endpoint directly) from pushing a large original into R2.

## Review notes
api-reviewer found no blocking issues on the initial diff. One
should-fix was raised and has since been addressed in a follow-up
commit:

- ~~`presign-service.ts` and `image-service.ts` hardcoded the limit in
  the error message string separately from `MAX_IMAGE_SIZE`~~ — fixed
  by introducing `MAX_IMAGE_SIZE_ERROR_MESSAGE` in
  `image-constraints.ts`, derived from the constant.

Remaining note (non-blocking, out of scope for this issue):

- `contentLength` in the presign flow is a client-supplied, non-binding
  sanity check — R2's presigned-PUT signature doesn't enforce it. This
  5MB check is advisory on the request path, same as the old 25MB one;
  a true hard backstop against an oversized object landing in R2 would
  need bucket-side enforcement or a post-upload check.

## Test plan
- [x] `pnpm test` — 193 tests passing
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSoajGLB56nf9qfenx4APy