### PR TITLE
fix: delete old R2 image on recipe update

### DIFF
--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -527,6 +527,8 @@ describe('PATCH /recipes/:id', () => {
       expect.anything(),
       1,
       expect.objectContaining({ description: null }),
+      TEST_ENV.IMAGE_BUCKET,
+      TEST_ENV.R2_PUBLIC_URL,
     )
   })
 
@@ -548,6 +550,8 @@ describe('PATCH /recipes/:id', () => {
       expect.anything(),
       1,
       expect.objectContaining({ imageUrl: 'recipes/xyz-789.jpg' }),
+      TEST_ENV.IMAGE_BUCKET,
+      TEST_ENV.R2_PUBLIC_URL,
     )
   })
 
@@ -558,6 +562,8 @@ describe('PATCH /recipes/:id', () => {
       expect.anything(),
       1,
       expect.objectContaining({ imageUrl: null }),
+      TEST_ENV.IMAGE_BUCKET,
+      TEST_ENV.R2_PUBLIC_URL,
     )
   })
 

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -196,7 +196,7 @@ recipeRouter.patch('/:id', requestLogger('recipe save'), async (c) => {
   const body = await c.req.json()
   const input = RecipeUpdateSchema.parse(body)
   if (input.imageUrl) input.imageUrl = toStorageKey(input.imageUrl, c.env.R2_PUBLIC_URL)
-  const data = await updateRecipe(db, id, input)
+  const data = await updateRecipe(db, id, input, c.env.IMAGE_BUCKET, c.env.R2_PUBLIC_URL)
   return c.json(
     buildSuccess(200, 'Recipe updated', withPublicImageUrl(data, c.env.R2_PUBLIC_URL)),
     200,

--- a/src/services/recipeService.test.ts
+++ b/src/services/recipeService.test.ts
@@ -318,12 +318,22 @@ describe('createRecipe', () => {
 })
 
 describe('updateRecipe', () => {
+  beforeEach(() => {
+    vi.mocked(deleteImage).mockReset()
+  })
+
   it('inserts null, not undefined, when ingredient notes and step tip are omitted', async () => {
     const { db, insertedValues } = makeRecipeDb(RECIPE_ROW)
-    await updateRecipe(db, 1, {
-      ingredients: [{ name: 'Spaghetti', unitId: 1, quantity: 200 }],
-      steps: [{ stepNumber: 1, description: 'Boil water' }],
-    })
+    await updateRecipe(
+      db,
+      1,
+      {
+        ingredients: [{ name: 'Spaghetti', unitId: 1, quantity: 200 }],
+        steps: [{ stepNumber: 1, description: 'Boil water' }],
+      },
+      makeBucket(),
+      PUBLIC_URL,
+    )
     const [ingredientValues] = valuesFor(insertedValues, recipeIngredients)
     const [stepValues] = valuesFor(insertedValues, recipeInstructionSteps)
     expect(ingredientValues.notes).toBeNull()
@@ -332,14 +342,88 @@ describe('updateRecipe', () => {
 
   it('normalizes the recipe name to title case when present', async () => {
     const { db, updatedValues } = makeRecipeDb(RECIPE_ROW)
-    await updateRecipe(db, 1, { name: 'creamy TOMATO soup' })
+    await updateRecipe(db, 1, { name: 'creamy TOMATO soup' }, makeBucket(), PUBLIC_URL)
     expect(updatedValues[0].name).toBe('Creamy Tomato Soup')
   })
 
   it('clears description to empty string, not null, when set to null', async () => {
     const { db, updatedValues } = makeRecipeDb(RECIPE_ROW)
-    await updateRecipe(db, 1, { description: null })
+    await updateRecipe(db, 1, { description: null }, makeBucket(), PUBLIC_URL)
     expect(updatedValues[0].description).toBe('')
+  })
+
+  it('does not delete an image when imageUrl is omitted', async () => {
+    const { db } = makeRecipeDb({ ...RECIPE_ROW, imageUrl: 'recipes/old.jpg' })
+    await updateRecipe(db, 1, { name: 'New Name' }, makeBucket(), PUBLIC_URL)
+    expect(vi.mocked(deleteImage)).not.toHaveBeenCalled()
+  })
+
+  it('does not delete the old image when imageUrl is cleared to null', async () => {
+    const { db } = makeRecipeDb({ ...RECIPE_ROW, imageUrl: 'recipes/old.jpg' })
+    await updateRecipe(db, 1, { imageUrl: null }, makeBucket(), PUBLIC_URL)
+    expect(vi.mocked(deleteImage)).not.toHaveBeenCalled()
+  })
+
+  it('does not delete anything when there was no previous image', async () => {
+    const { db } = makeRecipeDb({ ...RECIPE_ROW, imageUrl: null })
+    await updateRecipe(db, 1, { imageUrl: 'recipes/new.jpg' }, makeBucket(), PUBLIC_URL)
+    expect(vi.mocked(deleteImage)).not.toHaveBeenCalled()
+  })
+
+  it('does not delete the old image when the new imageUrl is unchanged', async () => {
+    const { db } = makeRecipeDb({ ...RECIPE_ROW, imageUrl: 'recipes/same.jpg' })
+    await updateRecipe(db, 1, { imageUrl: 'recipes/same.jpg' }, makeBucket(), PUBLIC_URL)
+    expect(vi.mocked(deleteImage)).not.toHaveBeenCalled()
+  })
+
+  it('deletes the old R2 object when imageUrl is replaced with a new key', async () => {
+    const { db } = makeRecipeDb({ ...RECIPE_ROW, imageUrl: 'recipes/old.jpg' })
+    vi.mocked(deleteImage).mockResolvedValue(undefined)
+    const bucket = makeBucket()
+
+    await updateRecipe(db, 1, { imageUrl: 'recipes/new.jpg' }, bucket, PUBLIC_URL)
+
+    expect(vi.mocked(deleteImage)).toHaveBeenCalledWith(bucket, 'recipes/old.jpg')
+  })
+
+  it('resolves a legacy full-URL previous imageUrl to a storage key before deleting', async () => {
+    const { db } = makeRecipeDb({
+      ...RECIPE_ROW,
+      imageUrl: `${PUBLIC_URL}/recipes/legacy.jpg`,
+    })
+    vi.mocked(deleteImage).mockResolvedValue(undefined)
+
+    await updateRecipe(db, 1, { imageUrl: 'recipes/new.jpg' }, makeBucket(), PUBLIC_URL)
+
+    expect(vi.mocked(deleteImage)).toHaveBeenCalledWith(expect.anything(), 'recipes/legacy.jpg')
+  })
+
+  it('does not delete the old image when the DB update fails', async () => {
+    const { db } = makeRecipeDb({ ...RECIPE_ROW, imageUrl: 'recipes/old.jpg' })
+    vi.mocked(db.transaction).mockRejectedValueOnce(new Error('db error'))
+
+    await expect(
+      updateRecipe(db, 1, { imageUrl: 'recipes/new.jpg' }, makeBucket(), PUBLIC_URL),
+    ).rejects.toThrow('db error')
+
+    expect(vi.mocked(deleteImage)).not.toHaveBeenCalled()
+  })
+
+  it('retries a failed old-image delete and gives up after 3 attempts without failing the update', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { db } = makeRecipeDb({ ...RECIPE_ROW, imageUrl: 'recipes/old.jpg' })
+    vi.mocked(deleteImage).mockRejectedValue(new Error('R2 unavailable'))
+
+    const promise = updateRecipe(db, 1, { imageUrl: 'recipes/new.jpg' }, makeBucket(), PUBLIC_URL)
+    await vi.runAllTimersAsync()
+    await expect(promise).resolves.toBeDefined()
+
+    expect(vi.mocked(deleteImage)).toHaveBeenCalledTimes(3)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"imageKey":"recipes/old.jpg"'))
+
+    errorSpy.mockRestore()
+    vi.useRealTimers()
   })
 })
 

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -335,13 +335,27 @@ export async function updateRecipe(
   db: Db,
   id: number,
   input: RecipeUpdateInput,
+  bucket: R2Bucket,
+  publicUrl: string,
 ): Promise<RecipeResponse> {
+  let replacedImageKey: string | null = null
+
   await db.transaction(async (tx) => {
     // tx is structurally compatible with Db; cast required due to Drizzle's type hierarchy
     const txDb = tx as unknown as Db
 
     const existing = await tx.query.recipes.findFirst({ where: eq(recipes.id, id) })
     if (!existing) throw new NotFoundError(`Recipe not found with id: ${id}`)
+
+    // Only the old image is orphaned by a replacement: a null imageUrl clears the field
+    // without uploading a new one (nothing to delete), and an omitted field leaves it
+    // untouched. Resolve the existing value to a key in case it's a legacy full URL.
+    if (input.imageUrl !== undefined && input.imageUrl !== null && existing.imageUrl) {
+      const oldKey = toStorageKey(existing.imageUrl, publicUrl)
+      if (oldKey !== input.imageUrl) {
+        replacedImageKey = oldKey
+      }
+    }
 
     // updatedAt is always set explicitly on PATCH, as required by the spec.
     // Note: unlike the Java source (which ignores null fields), null here nullifies
@@ -404,6 +418,10 @@ export async function updateRecipe(
     }
   })
 
+  if (replacedImageKey) {
+    await deleteRecipeImage(bucket, replacedImageKey, id)
+  }
+
   return fetchFullRecipe(db, id)
 }
 
@@ -426,10 +444,11 @@ export async function deleteRecipe(
   }
 }
 
-// The recipe row is already gone by the time this runs, so a failure here can't be
-// surfaced to the caller without falsely implying the delete failed. Retry a bounded
+// By the time this runs, the recipe row is either gone (deleteRecipe) or already
+// updated to point at the new image (updateRecipe), so a failure here can't be
+// surfaced to the caller without falsely implying the write failed. Retry a bounded
 // number of times, then log the orphaned key for manual/sweep cleanup rather than
-// blocking or failing the recipe delete response.
+// blocking or failing the recipe write response.
 async function deleteRecipeImage(bucket: R2Bucket, key: string, recipeId: number): Promise<void> {
   for (let attempt = 1; attempt <= IMAGE_DELETE_MAX_ATTEMPTS; attempt++) {
     try {


### PR DESCRIPTION
## Summary
- `updateRecipe` now deletes the previous R2 image object when `PATCH /recipes/:id` replaces `imageUrl` with a new non-null value, so the update path no longer orphans images in the `recipe-images` bucket (same failure mode as #67, fixed there for the delete path only).
- Resolves legacy full-URL `imageUrl` values to a storage key via `toStorageKey` before comparing/deleting, same as `deleteRecipe`.
- Reuses the existing bounded-retry/backoff/log-on-exhaustion helper from #67: the old image delete runs after the DB transaction commits and never fails or blocks the update response beyond the retry window.
- No-ops correctly: omitted `imageUrl`, explicit `null` (clears without a replacement), no previous image, and unchanged `imageUrl` all skip the delete.

## Test plan
- [x] `pnpm test` — 207 tests pass, including new `updateRecipe` coverage (skip cases, key deletion, legacy URL resolution, retry-then-give-up, no delete on failed DB update)
- [x] `pnpm run lint`
- [x] `pnpm run format:check`

Fixes #71