### PR TITLE
fix: add length checks to cuisine/ingredient name

### DIFF
--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -463,6 +463,68 @@ describe('POST /recipes', () => {
     expect(body.message).toBe('Cuisine request must have either an ID or a name.')
   })
 
+  it('returns 400 when cuisine name is too short', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, cuisine: { name: 'I' } },
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Cuisine name must be between 2 and 100 characters.')
+  })
+
+  it('returns 400 when cuisine name is too long', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, cuisine: { name: 'a'.repeat(101) } },
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Cuisine name must be between 2 and 100 characters.')
+  })
+
+  it('accepts a cuisine name at the max length boundary', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, cuisine: { name: 'a'.repeat(100) } },
+    })
+    expect(res.status).toBe(201)
+  })
+
+  it('returns 400 when ingredient name is too short', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, ingredients: [{ name: 'S', unitId: 1, quantity: 200 }] },
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Ingredient name must be between 2 and 150 characters.')
+  })
+
+  it('returns 400 when ingredient name is too long', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: {
+        ...SAVE_BODY,
+        ingredients: [{ name: 'a'.repeat(151), unitId: 1, quantity: 200 }],
+      },
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Ingredient name must be between 2 and 150 characters.')
+  })
+
+  it('accepts an ingredient name at the max length boundary', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: {
+        ...SAVE_BODY,
+        ingredients: [{ name: 'a'.repeat(150), unitId: 1, quantity: 200 }],
+      },
+    })
+    expect(res.status).toBe(201)
+  })
+
   it('propagates 404 from service when unit is not found', async () => {
     vi.mocked(recipeService.createRecipe).mockRejectedValue(
       new NotFoundError('Unit ID not found: 999'),

--- a/src/routes/recipes.test.ts
+++ b/src/routes/recipes.test.ts
@@ -491,6 +491,18 @@ describe('POST /recipes', () => {
     expect(res.status).toBe(201)
   })
 
+  // An explicit empty string now fails length validation before the object-level
+  // .refine() (id-or-name) check runs, so the message differs from the {} case above.
+  it('returns the length error, not the id-or-name error, for an explicit empty cuisine name', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, cuisine: { name: '' } },
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Cuisine name must be between 2 and 100 characters.')
+  })
+
   it('returns 400 when ingredient name is too short', async () => {
     const res = await request('/recipes', {
       method: 'POST',
@@ -498,7 +510,7 @@ describe('POST /recipes', () => {
     })
     expect(res.status).toBe(400)
     const body = (await res.json()) as Record<string, any>
-    expect(body.message).toBe('Ingredient name must be between 2 and 150 characters.')
+    expect(body.message).toBe('Ingredient name must be between 2 and 255 characters.')
   })
 
   it('returns 400 when ingredient name is too long', async () => {
@@ -506,12 +518,12 @@ describe('POST /recipes', () => {
       method: 'POST',
       body: {
         ...SAVE_BODY,
-        ingredients: [{ name: 'a'.repeat(151), unitId: 1, quantity: 200 }],
+        ingredients: [{ name: 'a'.repeat(256), unitId: 1, quantity: 200 }],
       },
     })
     expect(res.status).toBe(400)
     const body = (await res.json()) as Record<string, any>
-    expect(body.message).toBe('Ingredient name must be between 2 and 150 characters.')
+    expect(body.message).toBe('Ingredient name must be between 2 and 255 characters.')
   })
 
   it('accepts an ingredient name at the max length boundary', async () => {
@@ -519,10 +531,20 @@ describe('POST /recipes', () => {
       method: 'POST',
       body: {
         ...SAVE_BODY,
-        ingredients: [{ name: 'a'.repeat(150), unitId: 1, quantity: 200 }],
+        ingredients: [{ name: 'a'.repeat(255), unitId: 1, quantity: 200 }],
       },
     })
     expect(res.status).toBe(201)
+  })
+
+  it('returns the length error, not the id-or-name error, for an explicit empty ingredient name', async () => {
+    const res = await request('/recipes', {
+      method: 'POST',
+      body: { ...SAVE_BODY, ingredients: [{ name: '', unitId: 1, quantity: 200 }] },
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as Record<string, any>
+    expect(body.message).toBe('Ingredient name must be between 2 and 255 characters.')
   })
 
   it('propagates 404 from service when unit is not found', async () => {

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -34,8 +34,8 @@ const IngredientInputSchema = z
     id: z.number().int().positive().nullish(),
     name: z
       .string()
-      .min(2, 'Ingredient name must be between 2 and 150 characters.')
-      .max(150, 'Ingredient name must be between 2 and 150 characters.')
+      .min(2, 'Ingredient name must be between 2 and 255 characters.')
+      .max(255, 'Ingredient name must be between 2 and 255 characters.')
       .optional(),
     unitId: z.number().int().positive(),
     quantity: z.number().positive(),

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -19,7 +19,11 @@ export const recipeRouter = new Hono<{ Bindings: CloudflareBindings }>()
 const CuisineInputSchema = z
   .object({
     id: z.number().int().positive().nullish(),
-    name: z.string().optional(),
+    name: z
+      .string()
+      .min(2, 'Cuisine name must be between 2 and 100 characters.')
+      .max(100, 'Cuisine name must be between 2 and 100 characters.')
+      .optional(),
   })
   .refine((c) => c.id != null || (c.name?.trim().length ?? 0) > 0, {
     message: 'Cuisine request must have either an ID or a name.',
@@ -28,7 +32,11 @@ const CuisineInputSchema = z
 const IngredientInputSchema = z
   .object({
     id: z.number().int().positive().nullish(),
-    name: z.string().optional(),
+    name: z
+      .string()
+      .min(2, 'Ingredient name must be between 2 and 150 characters.')
+      .max(150, 'Ingredient name must be between 2 and 150 characters.')
+      .optional(),
     unitId: z.number().int().positive(),
     quantity: z.number().positive(),
     notes: z.string().nullish(),


### PR DESCRIPTION
## Summary
- `CuisineInputSchema.name` and `IngredientInputSchema.name` (`src/routes/recipes.ts`) had no `.min()`/`.max()` length checks, unlike `RecipeSaveSchema.name` (2-150 chars).
- Added matching bounds: cuisine name 2-100 chars (matches the `cuisines.name` varchar(100) column), ingredient name 2-255 chars (matches the `ingredients.name` varchar(255) column). Column length is the source of truth here since this repo is a port, not a redesign, and there's no other spec to defer to.
- min 2 is a new floor, chosen for consistency with the recipe name rule; there was no prior minimum on these two fields. `TagInputSchema.name` is untouched — issue #61 scoped this to cuisine/ingredient only, tags were out of scope.
- An explicit empty-string `name` (e.g. `cuisine: { name: '' }`) now fails length validation ("...must be between 2 and N characters.") instead of reaching the object-level "must have either an ID or a name" check, since `.min()` runs during field parsing. Covered by new tests.

## Test plan
- [x] `pnpm test` — 207 tests pass, including boundary tests (too short, too long, at-limit, explicit empty string) for both schemas
- [x] `pnpm run lint`
- [x] `pnpm run format:check`

Fixes #61